### PR TITLE
Add keywords for searching in Menu

### DIFF
--- a/data/com.rafaelmardojai.Blanket.desktop.in
+++ b/data/com.rafaelmardojai.Blanket.desktop.in
@@ -5,5 +5,7 @@ Exec=blanket
 Icon=com.rafaelmardojai.Blanket
 Terminal=false
 Type=Application
+# Translators: These are search terms to find this application. Do NOT translate or localize the semicolons. The list MUST also end with a semicolon.
+Keywords=Concentrate;Focus;Noise;Productivity;Sleep;
 Categories=AudioVideo;Audio;GTK;
 StartupNotify=true


### PR DESCRIPTION
Blanket will show up in the menu as the user searches for "Sleep","Focus" and so on.
Tested with Cinnamon in Linux Mint 20.