### PR TITLE
Update debian/changelog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+blanket (0.3.1) focal; urgency=medium
+
+  * bug fixes and translations
+
+ -- Archisman Panigrahi <apandada1@gmail.com>  Sun, 13 Sep 2020 08:16:37 +0530
+
 blanket (0.3.0-1) focal; urgency=medium
 
   * New version


### PR DESCRIPTION
Henceforth can you please edit the version number inside `()` in the first line of `debian/changelog` when you release a new version? 

You can optionally edit the release info (in the 3rd line) and other things (name, email, time), but only the new version number is really required.

For the daily builds, I have configured settings in launchpad to put the git commit after the main version number.