### PR TITLE
Update German and Slovak translations

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -210,7 +210,7 @@ msgstr ""
 
 #: src/about.py:12
 msgid "Sounds icons"
-msgstr "Klänge von"
+msgstr "Klang Symbole"
 
 #: src/about.py:13
 msgid "App icon"

--- a/po/sk.po
+++ b/po/sk.po
@@ -213,7 +213,7 @@ msgstr ""
 #: src/about.py:12
 #, fuzzy
 msgid "Sounds icons"
-msgstr "Zvuky od"
+msgstr "Zvukové ikony"
 
 #: src/about.py:13
 msgid "App icon"


### PR DESCRIPTION
"Klänge von" means "Sounds by", and not "Sound icons". Same mistake in the slovak translation.