### PR TITLE
Fixed typo: Autostart on...

### DIFF
--- a/blanket/preferences.py
+++ b/blanket/preferences.py
@@ -59,7 +59,7 @@ class PreferencesWindow(Handy.PreferencesWindow):
             'handle_token': GLib.Variant(
                 's', f'com/rafaelmardojai/Blanket/{token}'
             ),
-            'reason': GLib.Variant('s', _('Autostart Blanket on background.')),
+            'reason': GLib.Variant('s', _('Autostart Blanket in background.')),
             'autostart': GLib.Variant('b', active),
             'commandline': GLib.Variant('as', ['blanket', '--hidden']),
             'dbus-activatable': GLib.Variant('b', False)

--- a/data/resources/preferences.ui
+++ b/data/resources/preferences.ui
@@ -37,7 +37,7 @@
             <property name="visible">True</property>
             <child>
               <object class="HdyActionRow">
-                <property name="title" translatable="yes">Autostart on background</property>
+                <property name="title" translatable="yes">Autostart in background</property>
                 <property name="visible">True</property>
                 <property name="activatable_widget">autostart</property>
                 <child>

--- a/po/blanket.pot
+++ b/po/blanket.pot
@@ -69,7 +69,7 @@ msgid "Behavior"
 msgstr ""
 
 #: data/resources/preferences.ui:20
-msgid "Autostart on background"
+msgid "Autostart in background"
 msgstr ""
 
 #: data/resources/about.ui:11

--- a/po/ca.po
+++ b/po/ca.po
@@ -72,7 +72,7 @@ msgid "Behavior"
 msgstr "Comportament"
 
 #: data/resources/preferences.ui:20
-msgid "Autostart on background"
+msgid "Autostart in background"
 msgstr "Inici automàtic en segon pla"
 
 #: data/resources/about.ui:11

--- a/po/de.po
+++ b/po/de.po
@@ -72,7 +72,7 @@ msgid "Behavior"
 msgstr "Verhalten"
 
 #: data/resources/preferences.ui:20
-msgid "Autostart on background"
+msgid "Autostart in background"
 msgstr "Im Hintergrund starten"
 
 #: data/resources/about.ui:11

--- a/po/eo.po
+++ b/po/eo.po
@@ -72,7 +72,7 @@ msgid "Behavior"
 msgstr "Konduto"
 
 #: data/resources/preferences.ui:20
-msgid "Autostart on background"
+msgid "Autostart in background"
 msgstr "Aŭtolanĉi en la fono"
 
 #: data/resources/about.ui:11

--- a/po/es.po
+++ b/po/es.po
@@ -73,7 +73,7 @@ msgid "Behavior"
 msgstr "Comportamiento"
 
 #: data/resources/preferences.ui:20
-msgid "Autostart on background"
+msgid "Autostart in background"
 msgstr "Inicio automático en segundo plano "
 
 #: data/resources/about.ui:11

--- a/po/eu.po
+++ b/po/eu.po
@@ -72,7 +72,7 @@ msgid "Behavior"
 msgstr "Portaera"
 
 #: data/resources/preferences.ui:20
-msgid "Autostart on background"
+msgid "Autostart in background"
 msgstr "Hasi abioan"
 
 #: data/resources/about.ui:11

--- a/po/fi.po
+++ b/po/fi.po
@@ -72,7 +72,7 @@ msgid "Behavior"
 msgstr "Käyttäytyminen"
 
 #: data/resources/preferences.ui:20
-msgid "Autostart on background"
+msgid "Autostart in background"
 msgstr "Käynnistä taustalla automaattisesti"
 
 #: data/resources/about.ui:11

--- a/po/fr.po
+++ b/po/fr.po
@@ -72,7 +72,7 @@ msgid "Behavior"
 msgstr "Comportement"
 
 #: data/resources/preferences.ui:20
-msgid "Autostart on background"
+msgid "Autostart in background"
 msgstr "Démarrage automatique en arrière-plan"
 
 #: data/resources/about.ui:11

--- a/po/ga.po
+++ b/po/ga.po
@@ -73,7 +73,7 @@ msgid "Behavior"
 msgstr "Iompraíocht"
 
 #: data/resources/preferences.ui:20
-msgid "Autostart on background"
+msgid "Autostart in background"
 msgstr "Uath-thosú sa chúlra"
 
 #: data/resources/about.ui:11

--- a/po/hr.po
+++ b/po/hr.po
@@ -73,7 +73,7 @@ msgid "Behavior"
 msgstr "Ponašanje"
 
 #: data/resources/preferences.ui:20
-msgid "Autostart on background"
+msgid "Autostart in background"
 msgstr "Pokreni automatski u pozadini"
 
 #: data/resources/about.ui:11

--- a/po/id.po
+++ b/po/id.po
@@ -72,7 +72,7 @@ msgid "Behavior"
 msgstr "Perilaku"
 
 #: data/resources/preferences.ui:20
-msgid "Autostart on background"
+msgid "Autostart in background"
 msgstr "Mulai otomatis di latar belakang"
 
 #: data/resources/about.ui:11

--- a/po/it.po
+++ b/po/it.po
@@ -70,7 +70,7 @@ msgid "Behavior"
 msgstr "Comportamento"
 
 #: data/resources/preferences.ui:20
-msgid "Autostart on background"
+msgid "Autostart in background"
 msgstr "Avvio automatico in background"
 
 #: data/resources/about.ui:11

--- a/po/ja.po
+++ b/po/ja.po
@@ -69,7 +69,7 @@ msgid "Behavior"
 msgstr "挙動"
 
 #: data/resources/preferences.ui:20
-msgid "Autostart on background"
+msgid "Autostart in background"
 msgstr "バックグラウンドで自動スタート"
 
 #: data/resources/about.ui:11

--- a/po/ne.po
+++ b/po/ne.po
@@ -72,7 +72,7 @@ msgid "Behavior"
 msgstr "व्यवहार"
 
 #: data/resources/preferences.ui:20
-msgid "Autostart on background"
+msgid "Autostart in background"
 msgstr "पृष्ठभूमिमा अटोस्टार्ट होस्।"
 
 #: data/resources/about.ui:11

--- a/po/nl.po
+++ b/po/nl.po
@@ -72,7 +72,7 @@ msgid "Behavior"
 msgstr "Gedrag"
 
 #: data/resources/preferences.ui:20
-msgid "Autostart on background"
+msgid "Autostart in background"
 msgstr "Automatisch opstarten"
 
 #: data/resources/about.ui:11

--- a/po/oc.po
+++ b/po/oc.po
@@ -71,7 +71,7 @@ msgid "Behavior"
 msgstr "Compòrtament"
 
 #: data/resources/preferences.ui:20
-msgid "Autostart on background"
+msgid "Autostart in background"
 msgstr "Aviada automatica en rèireplan"
 
 #: data/resources/about.ui:11

--- a/po/pt.po
+++ b/po/pt.po
@@ -72,7 +72,7 @@ msgid "Behavior"
 msgstr "Comportamento"
 
 #: data/resources/preferences.ui:20
-msgid "Autostart on background"
+msgid "Autostart in background"
 msgstr "Iniciar automaticamente em segundo plano"
 
 #: data/resources/about.ui:11

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -72,7 +72,7 @@ msgid "Behavior"
 msgstr "Comportamento"
 
 #: data/resources/preferences.ui:20
-msgid "Autostart on background"
+msgid "Autostart in background"
 msgstr "Iniciar automaticamente em segundo plano"
 
 #: data/resources/about.ui:11

--- a/po/ru_RU.po
+++ b/po/ru_RU.po
@@ -71,7 +71,7 @@ msgid "Behavior"
 msgstr "Поведение"
 
 #: data/resources/preferences.ui:20
-msgid "Autostart on background"
+msgid "Autostart in background"
 msgstr "Автозапуск в фоновом режиме"
 
 #: data/resources/about.ui:11

--- a/po/sk.po
+++ b/po/sk.po
@@ -72,7 +72,7 @@ msgid "Behavior"
 msgstr "Správanie"
 
 #: data/resources/preferences.ui:20
-msgid "Autostart on background"
+msgid "Autostart in background"
 msgstr "Automaticky spustiť na pozadí"
 
 #: data/resources/about.ui:11

--- a/po/sv.po
+++ b/po/sv.po
@@ -80,7 +80,7 @@ msgid "Behavior"
 msgstr "Beteende"
 
 #: data/resources/preferences.ui:40
-msgid "Autostart on background"
+msgid "Autostart in background"
 msgstr "Starta automatiskt i bakgrunden"
 
 #: data/resources/about.ui:11

--- a/po/ta.po
+++ b/po/ta.po
@@ -71,7 +71,7 @@ msgid "Behavior"
 msgstr "நடத்தை"
 
 #: data/resources/preferences.ui:20
-msgid "Autostart on background"
+msgid "Autostart in background"
 msgstr "பின்னணியில் தானாக துவங்கு"
 
 #: data/resources/about.ui:11

--- a/po/tr.po
+++ b/po/tr.po
@@ -72,7 +72,7 @@ msgid "Behavior"
 msgstr "Davranış"
 
 #: data/resources/preferences.ui:20
-msgid "Autostart on background"
+msgid "Autostart in background"
 msgstr "Arka planda otomatik başlat"
 
 #: data/resources/about.ui:11

--- a/po/uk.po
+++ b/po/uk.po
@@ -73,7 +73,7 @@ msgid "Behavior"
 msgstr "Поведінка"
 
 #: data/resources/preferences.ui:20
-msgid "Autostart on background"
+msgid "Autostart in background"
 msgstr "Автозапуск у фоні"
 
 #: data/resources/about.ui:11

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -70,7 +70,7 @@ msgid "Behavior"
 msgstr "行为"
 
 #: data/resources/preferences.ui:20
-msgid "Autostart on background"
+msgid "Autostart in background"
 msgstr "系统启动后自动在后台运行"
 
 #: data/resources/about.ui:11


### PR DESCRIPTION
Excellent application, but impossible to use... with this typo:

Autostart on background -> Autostart **in** background