### PR TITLE
Fix MIME type for FLAC

### DIFF
--- a/blanket/window.py
+++ b/blanket/window.py
@@ -209,7 +209,7 @@ class BlanketWindow(Handy.ApplicationWindow):
     def open_audio(self):
         filters = {
             'OGG': ['audio/ogg'],
-            'FLAC': ['audio/x-flac'],
+            'FLAC': ['audio/flac'],
             'WAV': ['audio/x-wav', 'audio/wav'],
             'MP3': ['audio/mpeg'],
         }


### PR DESCRIPTION
The correct MIME type for FLAC is `audio/flac`.

```
$ file --mime-type 1-Big\ Love.flac 
1-Big Love.flac: audio/flac
```

```
$ ls /usr/share/mime/audio/ | grep flac
flac.xml
x-flac+ogg.xml
```

```
$ grep flac /usr/share/mime/aliases
audio/x-flac audio/flac
audio/x-oggflac audio/x-flac+ogg
```

https://en.wikipedia.org/wiki/FLAC
https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Containers#flac