### PR TITLE
 Update debian dependencies - libhandy -> libadwaita

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+blanket (0.6.0) jammy; urgency=medium
+
+  * New version - GTK4
+
+ -- Rafael Mardojai CM <email@rafaelmardojai.com> Thu, 14 Apr 2021 12:04:42 +0530
+
 blanket (0.5.0) focal; urgency=medium
 
   * New version

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Build-Depends: debhelper-compat(=10),
 	meson (>= 0.50),
 	pkg-config,
 	libglib2.0-dev,
-	libhandy-1-dev,
+	libadwaita-1-dev,
 	appstream
 Standards-Version: 4.5.0
 Rules-Requires-Root: no
@@ -19,9 +19,8 @@ Vcs-Git: https://github.com/rafaelmardojai/blanket.git
 Package: blanket
 Architecture: all
 Depends: ${misc:Depends},
-	gir1.2-handy-1,
+	gir1.2-adw-1,
 	gir1.2-gst-plugins-bad-1.0,
-	gir1.2-gtk-3.0,
 	python3
 Description: Listen to different sounds
  Improve focus and increase your productivity by listening to different sounds.


### PR DESCRIPTION
Updated dependencies (libadwaita) for Debian, and the PPA package works on Ubuntu 22.04 and Mint 21.