### PR TITLE
Add Play and Pause methods for MPRIS integration

### DIFF
--- a/blanket/main.py
+++ b/blanket/main.py
@@ -162,6 +162,12 @@ class Application(Adw.Application):
         # Change mainplayer playing
         self.mainplayer.playing = playing
 
+    def on_play(self, _action=None, _param=None):
+        self.mainplayer.playing = True
+
+    def on_pause(self, _action=None, _param=None):
+        self.mainplayer.playing = False
+
     def on_reset_volumes(self, _action, _param):
         self.mainplayer.reset_volumes()
 

--- a/blanket/mpris.py
+++ b/blanket/mpris.py
@@ -108,6 +108,8 @@ class MPRIS(Server):
         </interface>
         <interface name="org.mpris.MediaPlayer2.Player">
             <method name="PlayPause"/>
+            <method name="Play"/>
+            <method name="Pause"/>
             <property name="PlaybackStatus" type="s" access="read"/>
             <property name="Metadata" type="a{sv}" access="read">
             </property>
@@ -161,6 +163,12 @@ class MPRIS(Server):
 
     def PlayPause(self):
         self.app.on_playpause()
+
+    def Play(self):
+        self.app.on_play()
+
+    def Pause(self):
+        self.app.on_pause()
 
     def Get(self, interface, property_name):
         if property_name in [


### PR DESCRIPTION
Adds support for the Play and Pause methods from the MPRIS2 spec https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html

I tend to use https://github.com/altdesktop/playerctl to manage the media players on my system, so having those commands integrated helps when controlling Blanket