### PR TITLE
Update help-overlay

### DIFF
--- a/blanket/main.py
+++ b/blanket/main.py
@@ -119,7 +119,8 @@ class Application(Adw.Application):
             },
             {
                 'name': 'preferences',
-                'func': self.on_preferences
+                'func': self.on_preferences,
+                'accels': ['<Ctl>comma']
             },
             {
                 'name': 'about',

--- a/blanket/main.py
+++ b/blanket/main.py
@@ -122,10 +122,6 @@ class Application(Adw.Application):
                 'func': self.on_preferences
             },
             {
-                'name': 'shortcuts',
-                'func': self.on_shortcuts
-            },
-            {
                 'name': 'about',
                 'func': self.on_about
             },
@@ -219,15 +215,6 @@ class Application(Adw.Application):
     def on_preferences(self, _action, _param):
         window = PreferencesWindow(self.window)
         window.set_transient_for(self.window)
-        window.set_modal(True)
-        window.present()
-
-    def on_shortcuts(self, _action, _param):
-        window = Gtk.Builder.new_from_resource(
-            '/com/rafaelmardojai/Blanket/shortcuts.ui'
-        ).get_object('shortcuts')
-        window.set_transient_for(self.window)
-        window.props.section_name = 'shortcuts'
         window.set_modal(True)
         window.present()
 

--- a/data/resources/blanket.gresource.xml
+++ b/data/resources/blanket.gresource.xml
@@ -8,7 +8,7 @@
     <file>preset-dialog.ui</file>
     <file>preset-row.ui</file>
     <file>about.ui</file>
-    <file>shortcuts.ui</file>
+    <file alias="gtk/help-overlay.ui">shortcuts.ui</file>
     <file>sound-row.ui</file>
 
     <!-- CSS -->

--- a/data/resources/shortcuts.ui
+++ b/data/resources/shortcuts.ui
@@ -28,6 +28,12 @@
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
+                <property name="action-name">app.preferences</property>
+                <property name="title" translatable="yes">Preferences</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
                 <property name="action-name">win.show-help-overlay</property>
                 <property name="title" translatable="yes">Keyboard shortcus</property>
               </object>

--- a/data/resources/shortcuts.ui
+++ b/data/resources/shortcuts.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.22.1 -->
 <interface>
-  <object class="GtkShortcutsWindow" id="shortcuts">
+  <object class="GtkShortcutsWindow" id="help_overlay">
     <child>
       <object class="GtkShortcutsSection">
         <property name="section-name">shortcuts</property>
@@ -24,6 +24,12 @@
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">&lt;ctrl&gt;W</property>
                 <property name="title" translatable="yes">Close window</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="action-name">win.show-help-overlay</property>
+                <property name="title" translatable="yes">Keyboard shortcus</property>
               </object>
             </child>
             <child>

--- a/data/resources/shortcuts.ui
+++ b/data/resources/shortcuts.ui
@@ -10,19 +10,19 @@
             <property name="title" translatable="yes">General</property>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="accelerator">&lt;ctrl&gt;M space</property>
+                <property name="action-name">app.playpause</property>
                 <property name="title" translatable="yes">Play/Pause sounds</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="accelerator">&lt;ctrl&gt;O</property>
+                <property name="action-name">app.open</property>
                 <property name="title" translatable="yes">Add custom sound</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="accelerator">&lt;ctrl&gt;W</property>
+                <property name="action-name">app.close</property>
                 <property name="title" translatable="yes">Close window</property>
               </object>
             </child>
@@ -40,7 +40,7 @@
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="accelerator">&lt;ctrl&gt;Q</property>
+                <property name="action-name">app.quit</property>
                 <property name="title" translatable="yes">Quit</property>
               </object>
             </child>

--- a/data/resources/window.ui
+++ b/data/resources/window.ui
@@ -91,7 +91,7 @@
       </item>
       <item>
         <attribute name="label" translatable="yes">Keyboard Shortcuts</attribute>
-        <attribute name="action">app.shortcuts</attribute>
+        <attribute name="action">win.show-help-overlay</attribute>
       </item>
       <item>
         <attribute name="label" translatable="yes">About Blanket</attribute>


### PR DESCRIPTION
This MR contains two patches:

Remove excessive show-help-overlay action
- We don't need an extra action to show help-overlay. It already managed by GTK.

Add preferences shortcut
- Ctrl+comma is the standard shortcut for Preferences across GNOME. Add support for it to comply GNOME HIG.

Convert Accellerator properties to action-names
- action-names are more maintainable than accellerator properties.


