### PR TITLE
ci.yml: bump actions/checkout to v3 to fix node warning

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ jobs:
       image: bilelmoussaoui/flatpak-github-actions:gnome-nightly
       options: --privileged
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v6
       with:
         bundle: "blanket-devel.flatpak"


### PR DESCRIPTION
Sorry, I forgot to do it in the previous PR.

This PR fixes the Node 12 deprecation warning by bumping the `actions/checkout` version to `v3` (Node 16).