### PR TITLE
main: Pause playback if the system enters power saver mode

### DIFF
--- a/blanket/main.py
+++ b/blanket/main.py
@@ -95,6 +95,10 @@ class Application(Adw.Application):
         action.connect('activate', self.on_playpause)
         self.add_action(action)
 
+        action = Gio.SimpleAction.new('play', None)
+        action.connect('activate', self.on_play)
+        self.add_action(action)
+
         # Create new preset from active
         action = Gio.SimpleAction.new('add-preset', None)
         action.connect('activate', self.on_add_preset)

--- a/blanket/window.py
+++ b/blanket/window.py
@@ -21,6 +21,7 @@ class BlanketWindow(Adw.ApplicationWindow):
     __gtype_name__ = 'BlanketWindow'
 
     headerbar = Gtk.Template.Child()
+    toast_overlay = Gtk.Template.Child()
     grid = Gtk.Template.Child()
     playpause_btn: PlayPauseButton = Gtk.Template.Child()
     volumes = Gtk.Template.Child()
@@ -28,6 +29,7 @@ class BlanketWindow(Adw.ApplicationWindow):
     volume_box = Gtk.Template.Child()
     volume_list = Gtk.Template.Child()
     presets_chooser: PresetChooser = Gtk.Template.Child()
+    power_toast = Gtk.Template.Child()
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -242,3 +244,9 @@ class BlanketWindow(Adw.ApplicationWindow):
 
     def __update_volume_model(self):
         self.volume_filter.changed(Gtk.FilterChange.DIFFERENT)
+
+    def show_power_toast(self):
+        self.toast_overlay.add_toast(self.power_toast)
+
+    def hide_power_toast(self):
+        self.power_toast.dismiss()

--- a/data/resources/window.blp
+++ b/data/resources/window.blp
@@ -23,22 +23,24 @@ template $BlanketWindow : Adw.ApplicationWindow {
       }
     }
 
-    ScrolledWindow {
-      hscrollbar-policy: never;
-      hexpand: true;
-      vexpand: true;
+    Adw.ToastOverlay toast_overlay {
+      ScrolledWindow {
+        hscrollbar-policy: never;
+        hexpand: true;
+        vexpand: true;
 
-      FlowBox grid {
-        activate-on-single-click: true;
-        column-spacing: 12;
-        row-spacing: 12;
-        homogeneous: true;
-        selection-mode: none;
-        valign: start;
+        FlowBox grid {
+          activate-on-single-click: true;
+          column-spacing: 12;
+          row-spacing: 12;
+          homogeneous: true;
+          selection-mode: none;
+          valign: start;
 
-        styles [
-          "sound-view",
-        ]
+          styles [
+            "sound-view",
+          ]
+        }
       }
     }
 
@@ -185,4 +187,10 @@ Adjustment volume_adjustment {
   upper: 1;
   step-increment: 0.01;
   page-increment: 0.01;
+}
+
+Adw.Toast power_toast {
+  title: _("Paused to save power");
+  action-name: "app.play";
+  button-label: _("_Resume Playing");
 }


### PR DESCRIPTION
The system might enter power saver mode because the battery is low, or
because the user explicitly enabled it in anticipation of being away
from a power supply for a long time, for example.

Constant audio playback is a significant consumer of power, so listen to
the signals from `GPowerProfileMonitor` and automatically pause playback
when entering low power mode.

Because the reason for pausing playback might be unclear to the user
(they might not be aware their battery has just reached a new critical
level), show a toast explaining why playback has been paused, and giving
a button to start playback again. The toast is dismissed if the user
explicitly presses the play button too.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>