### PR TITLE
Add AAC as supported audio format

### DIFF
--- a/blanket/window.py
+++ b/blanket/window.py
@@ -167,11 +167,13 @@ class BlanketWindow(Adw.ApplicationWindow):
                 'audio/x-wav',
                 'audio/wav',
                 'audio/mpeg',
+                'audio/aac',
             ],
             'Ogg': ['audio/ogg'],
             'FLAC': ['audio/flac'],
             'WAV': ['audio/x-wav', 'audio/wav'],
             'MP3': ['audio/mpeg'],
+            'AAC': ['audio/aac'],
         }
 
         self.filechooser = Gtk.FileChooserNative.new(  # type: ignore


### PR DESCRIPTION
I have a collection of sounds I really like and I downloaded them through `yt-dlp` which is usually encoded in aac and opus.

`yt-dlp` usually outputs aac into .m4a container which can hold either aac or alac. I tested an .m4a with alac and it didn't play, so I stuck with using .aac file format, which has its own mime type. Ffmpeg lets you `ffmpeg -i in.m4a -c:a copy out.aac`

This change makes it a lot easier to import from `yt-dlp` without re-encoding. It's better to leave the codec the way it is to reduce data loss or unnecessarily increase file size.

Let me know if you want me to test opus or consider adding m4a. Thank you so much for the cute cozy program. Blanket is really really nice! It helps me feel so grounded and comfy cause it's GTK 4.