### PR TITLE
appdata: Remove Purism metadata

### DIFF
--- a/data/com.rafaelmardojai.Blanket.metainfo.xml.in
+++ b/data/com.rafaelmardojai.Blanket.metainfo.xml.in
@@ -157,8 +157,4 @@
       </description>
     </release>
   </releases>
-  <custom>
-    <value key="Purism::form_factor">workstation</value>
-    <value key="Purism::form_factor">mobile</value>
-  </custom>
 </component>


### PR DESCRIPTION
This metadata is invalid: custom data is a dictionary and using the same key multiple times in a dictionary does not work

More information: https://github.com/ximion/appstream/issues/476