### PR TITLE
draft: Appstream related patches

### DIFF
--- a/data/com.rafaelmardojai.Blanket.metainfo.xml.in
+++ b/data/com.rafaelmardojai.Blanket.metainfo.xml.in
@@ -37,22 +37,36 @@
   <url type="bugtracker">https://github.com/rafaelmardojai/blanket/issues</url>
   <url type="translate">https://hosted.weblate.org/engage/blanket/</url>
   <url type="donation">https://rafaelmardojai.com/donate/</url>
-  <developer_name>Rafael Mardojai CM</developer_name>
+  <url type="vcs-browser">https://github.com/rafaelmardojai/blanket</url>
+  <developer_name translatable="no">Rafael Mardojai CM</developer_name>
   <update_contact>email_AT_rafaelmardojai.com</update_contact>
   <content_rating type="oars-1.1" />
 
   <launchable type="desktop-id">com.rafaelmardojai.Blanket.desktop</launchable>
   <translation type="gettext">blanket</translation>
+  
+  <categories>
+    <category>AudioVideo</category>
+    <category>Audio</category>
+    <category>GTK</category>
+  </categories>
+  <keywords>
+    <keyword>Concentrate</keyword>
+    <keyword>Focus</keyword>
+    <keyword>Noise</keyword>
+    <keyword>Productivity</keyword>
+    <keyword>Sleep</keyword>
+  </keywords>
 
   <screenshots>
     <screenshot  type="default">
-      <image>https://raw.githubusercontent.com/rafaelmardojai/blanket/master/brand/screenshot-1.png</image>
+      <image type="source">https://raw.githubusercontent.com/rafaelmardojai/blanket/master/brand/screenshot-1.png</image>
     </screenshot>
     <screenshot>
-      <image xml:lang="ru">https://raw.githubusercontent.com/rafaelmardojai/blanket/master/brand/screenshots/ru/screenshot-1-ru.z.png</image>
+      <image type="source" xml:lang="ru">https://raw.githubusercontent.com/rafaelmardojai/blanket/master/brand/screenshots/ru/screenshot-1-ru.z.png</image>
     </screenshot>
     <screenshot>
-      <image xml:lang="ru">https://raw.githubusercontent.com/rafaelmardojai/blanket/master/brand/screenshots/ru/screenshot-2-ru.z.png</image>
+      <image type="source" xml:lang="ru">https://raw.githubusercontent.com/rafaelmardojai/blanket/master/brand/screenshots/ru/screenshot-2-ru.z.png</image>
     </screenshot>
   </screenshots>
 

--- a/data/meson.build
+++ b/data/meson.build
@@ -24,10 +24,10 @@ appstream_file = i18n.merge_file(
   install_dir: join_paths(get_option('datadir'), 'metainfo')
 )
 
-appstream_util = find_program('appstream-util', required: false)
-if appstream_util.found()
-  test('Validate appstream file', appstream_util,
-    args: ['validate-relax', appstream_file]
+appstreamcli = find_program('appstreamcli', required: false)
+if appstreamcli.found()
+  test('Validate appstream file', appstreamcli,
+    args: ['validate', '--no-net', appstream_file]
   )
 endif
 


### PR DESCRIPTION
### appdata: use appstreamcli for appdata validation

appstream-util is obsoleted by appstreamcli.

### appdata: Update appdata

- Add cvs-browser URL.
- Mark the developer name as untranslatable.
- Add Categories and keywords
- Try to fix appdata screenshot error.
