### PR TITLE
appdata: Improve appdata for AppStream 1.0

### DIFF
--- a/com.rafaelmardojai.Blanket.json
+++ b/com.rafaelmardojai.Blanket.json
@@ -41,6 +41,7 @@
             "name" : "blanket",
             "builddir" : true,
             "buildsystem" : "meson",
+            "run-tests" : true,
             "sources" : [
                 {
                     "type" : "dir",

--- a/data/com.rafaelmardojai.Blanket.metainfo.xml.in
+++ b/data/com.rafaelmardojai.Blanket.metainfo.xml.in
@@ -38,7 +38,11 @@
   <url type="translate">https://hosted.weblate.org/engage/blanket/</url>
   <url type="donation">https://rafaelmardojai.com/donate/</url>
   <url type="vcs-browser">https://github.com/rafaelmardojai/blanket</url>
+  <!-- developer_name tag deprecated with Appstream 1.0 -->
   <developer_name translatable="no">Rafael Mardojai CM</developer_name>
+  <developer id="github.com">
+      <name translatable="no">Rafael Mardojai CM</name>
+  </developer>
   <update_contact>email_AT_rafaelmardojai.com</update_contact>
   <content_rating type="oars-1.1" />
 

--- a/data/com.rafaelmardojai.Blanket.metainfo.xml.in
+++ b/data/com.rafaelmardojai.Blanket.metainfo.xml.in
@@ -45,21 +45,6 @@
   <launchable type="desktop-id">com.rafaelmardojai.Blanket.desktop</launchable>
   <translation type="gettext">blanket</translation>
 
-  <categories>
-    <category>AudioVideo</category>
-    <category>Audio</category>
-    <category>GTK</category>
-  </categories>
-
-  <keywords>
-    <keyword translate="no">Blanket</keyword>
-    <keyword>Concentrate</keyword>
-    <keyword>Focus</keyword>
-    <keyword>Noise</keyword>
-    <keyword>Productivity</keyword>
-    <keyword>Sleep</keyword>
-  </keywords>
-
   <screenshots>
     <screenshot type="default">
       <image type="source">https://raw.githubusercontent.com/rafaelmardojai/blanket/master/brand/screenshot-1.png</image>

--- a/data/meson.build
+++ b/data/meson.build
@@ -27,7 +27,8 @@ appstream_file = i18n.merge_file(
 appstreamcli = find_program('appstreamcli', required: false)
 if appstreamcli.found()
   test('Validate appstream file', appstreamcli,
-    args: ['validate', '--no-net', appstream_file]
+    args: ['validate', '--no-net', '--explain', appstream_file],
+    workdir: meson.current_build_dir()
   )
 endif
 


### PR DESCRIPTION
### appdata: Improve appdata for AppStream 1.0

- Add the `<developer><name>` tag
- Mark the `<developer_name>` tag as deprecated
- Improve appstreamcli parameters
- Activate meson tests on Flatpak manifest

### appdata: Fix my mistake

"Icons and categories

If there’s a type="desktop-id" launchable, they get pulled from it.
Most of the icon not found errors with the flathub builder can be
traced down to the launchable value not matching the desktop file name.

Don’t set them in the AppData unless you want to override them
(even though then it might be a better idea to patch the desktop file
itself)."

More information: https://docs.flathub.org/docs/for-app-authors/appdata-guidelines/#icons-and-categories