### PR TITLE
feat: Port dialogs to`Adw.Dialog`, update `blueprint-compiler`, ...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 
 builddir/
 .flatpak/
+.flatpak-builder
 _build/
 
 

--- a/blanket/main.py
+++ b/blanket/main.py
@@ -23,7 +23,7 @@ except ImportError or ValueError as exc:
 from blanket.define import AUTHORS, ARTISTS, RES_PATH, SOUND_ARTISTS, SOUND_EDITORS
 from blanket.main_player import MainPlayer
 from blanket.mpris import MPRIS
-from blanket.preferences import PreferencesWindow
+from blanket.preferences import PreferencesDialog
 from blanket.settings import Settings
 from blanket.widgets import PresetDialog
 from blanket.window import BlanketWindow
@@ -89,12 +89,12 @@ class Application(Adw.Application):
         action.connect('activate', self.on_quit)
         self.add_action(action)
 
-        # Show about window
+        # Show about dialog
         action = Gio.SimpleAction.new('about', None)
         action.connect('activate', self.on_about)
         self.add_action(action)
 
-        # Show preferences window
+        # Show preferences dialog
         action = Gio.SimpleAction.new('preferences', None)
         action.connect('activate', self.on_preferences)
         self.add_action(action)
@@ -223,14 +223,12 @@ class Application(Adw.Application):
             self.window.props.hide_on_close = value
 
     def on_preferences(self, _action, _param):
-        window = PreferencesWindow(self.window)
-        window.set_transient_for(self.window)
-        window.set_modal(True)
-        window.present()
+        prefs = PreferencesDialog(self.window)
+        prefs.present(self.window)
 
     def on_about(self, _action, _param):
         builder = Gtk.Builder.new_from_resource(f'{RES_PATH}/about.ui')
-        about: Adw.AboutWindow = builder.get_object('about')  # type: ignore
+        about: Adw.AboutDialog = builder.get_object('about')  # type: ignore
 
         artists = self.__get_credits_list(ARTISTS)
         sound_artists = self.__get_credits_list(SOUND_ARTISTS)
@@ -239,11 +237,11 @@ class Application(Adw.Application):
         about.set_version(self.version)
         about.set_developers(AUTHORS)
         about.set_designers(artists)
+        about.add_link(_('Source Code'), 'https://github.com/rafaelmardojai/blanket')
         about.add_credit_section(_('Sounds by'), sound_artists)
         about.add_credit_section(_('Sounds edited by'), sound_editors)
 
-        about.set_transient_for(self.window)
-        about.present()
+        about.present(self.window)
 
     def on_quit(self, _action, _param):
         self.quit()

--- a/blanket/preferences.py
+++ b/blanket/preferences.py
@@ -12,8 +12,8 @@ from blanket.settings import Settings
 
 
 @Gtk.Template(resource_path=f'{RES_PATH}/preferences.ui')
-class PreferencesWindow(Adw.PreferencesWindow):
-    __gtype_name__ = 'PreferencesWindow'
+class PreferencesDialog(Adw.PreferencesDialog):
+    __gtype_name__ = 'PreferencesDialog'
 
     dark_group: Adw.PreferencesGroup = Gtk.Template.Child()  # type: ignore
     dark: Adw.SwitchRow = Gtk.Template.Child()  # type: ignore
@@ -104,16 +104,9 @@ class PreferencesWindow(Adw.PreferencesWindow):
         except Exception as e:
             print(e)
 
-            error_dialog = Gtk.MessageDialog(
-                message_type=Gtk.MessageType.WARNING,
-                buttons=Gtk.ButtonsType.OK,
-                text=_('Request error'),
-            )
-            error_dialog.props.transient_for = self
-            error_dialog.props.modal = True
-            error_dialog.props.secondary_text = _('The autostart request failed.')
-            error_dialog.connect('response', self.__on_dialog_response)
-            error_dialog.present()
+            error_dialog = Adw.AlertDialog.new(_('Request error'), _('The autostart request failed.'))
+            error_dialog.add_response('ok', _('Ok'))
+            error_dialog.present(self.window)
             self.autostart_failed = True
             self.autostart.set_active(self.autostart_saved)
 
@@ -128,39 +121,17 @@ class PreferencesWindow(Adw.PreferencesWindow):
             pass
         elif state == 1:
             if active:
-                error_dialog = Gtk.MessageDialog(
-                    message_type=Gtk.MessageType.WARNING,
-                    buttons=Gtk.ButtonsType.OK,
-                    text=_('Authorization failed'),
-                )
-                error_dialog.props.transient_for = self
-                error_dialog.props.modal = True
-                error_dialog.props.secondary_text = _(
-                    'Make sure Blanket has permission to run in '
-                    '\nthe background in Settings → Applications → '
-                    '\nBlanket and try again.'
-                )
-                error_dialog.connect('response', self.__on_dialog_response)
-                error_dialog.present()
+                error_dialog = Adw.AlertDialog.new(_('Authorization failed'), _('Make sure Blanket has permission to run in the background in Settings → Applications → Blanket and try again.'))
+                error_dialog.add_response('ok', _('Ok'))
+                error_dialog.present(self.window)
         elif state == 2:
-            error_dialog = Gtk.MessageDialog(
-                message_type=Gtk.MessageType.WARNING,
-                buttons=Gtk.ButtonsType.OK,
-                text=_('Request error'),
-            )
-            error_dialog.props.transient_for = self
-            error_dialog.props.modal = True
-            error_dialog.props.secondary_text = _('The autostart request failed.')
-            error_dialog.connect('response', self.__on_dialog_response)
-            error_dialog.present()
+            error_dialog = Adw.AlertDialog.new(_('Request error'), _('The autostart request failed.'))
+            error_dialog.add_response('ok', _('Ok'))
+            error_dialog.present(self.window)
 
         self.autostart.set_active(autostart)
         Settings.get().autostart = autostart
         return
-
-    def __on_dialog_response(self, dialog, response_id):
-        if response_id == Gtk.ResponseType.OK:
-            dialog.destroy()
 
     def __get_window_identifier(self):
         session = os.getenv('XDG_SESSION_TYPE')

--- a/blanket/window.py
+++ b/blanket/window.py
@@ -129,18 +129,17 @@ class BlanketWindow(Adw.ApplicationWindow):
             else:
                 Settings.get().remove_custom_audio(name)
 
-                message = Adw.MessageDialog.new(
-                    self,
+                alert = Adw.AlertDialog.new(
                     _('Sound Automatically Removed'),
                     _(
                         'The {name} sound is no longer accessible, so it has been removed'
                     ).format(name=f'<b><i>{name}</i></b>'),
                 )
-                message.add_response('accept', _('Accept'))
-                message.props.body_use_markup = True
-                message.props.default_response = 'accept'
-                message.props.close_response = 'accept'
-                message.present()
+                alert.add_response('accept', _('Accept'))
+                alert.props.body_use_markup = True
+                alert.props.default_response = 'accept'
+                alert.props.close_response = 'accept'
+                alert.present(self)
 
     def open_audio(self):
         def on_response(_filechooser, _id):
@@ -179,6 +178,7 @@ class BlanketWindow(Adw.ApplicationWindow):
         self.filechooser = Gtk.FileChooserNative.new(  # type: ignore
             _('Open audio'), self, Gtk.FileChooserAction.OPEN, None, None
         )
+        self.filechooser.set_modal(True)
         self.filechooser.connect('response', on_response)
 
         for f, mts in filters.items():

--- a/com.rafaelmardojai.Blanket.json
+++ b/com.rafaelmardojai.Blanket.json
@@ -32,8 +32,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler",
-                    "tag": "v0.8.1",
-                    "commit": "aa7679618e864748f4f4d8f15283906e712752fe"
+                    "tag": "v0.10.0",
+                    "commit": "2a39a16391122af2f3d812e478c1c1398c98b972"
                 }
             ]
         },

--- a/data/com.rafaelmardojai.Blanket.metainfo.xml.in
+++ b/data/com.rafaelmardojai.Blanket.metainfo.xml.in
@@ -33,7 +33,7 @@
       <li>Wind</li>
     </ul>
   </description>
-  <url type="homepage">https://github.com/rafaelmardojai/blanket</url>
+  <url type="homepage">https://apps.gnome.org/Blanket</url>
   <url type="bugtracker">https://github.com/rafaelmardojai/blanket/issues</url>
   <url type="translate">https://hosted.weblate.org/engage/blanket/</url>
   <url type="donation">https://rafaelmardojai.com/donate/</url>

--- a/data/resources/about.blp
+++ b/data/resources/about.blp
@@ -1,13 +1,12 @@
 using Gtk 4.0;
 using Adw 1;
 
-Adw.AboutWindow about {
-  destroy-with-parent: true;
+Adw.AboutDialog about {
   application-name: "Blanket";
   comments: _("Listen to different sounds");
   copyright: _("Copyright 2020-2022 Rafael Mardojai CM");
   developer-name: _("Rafael Mardojai CM");
-  website: "https://github.com/rafaelmardojai/blanket/";
+  website: "https://apps.gnome.org/Blanket";
   issue-url: "https://github.com/rafaelmardojai/blanket/issues";
   application-icon: "com.rafaelmardojai.Blanket";
   license-type: gpl_3_0;

--- a/data/resources/preferences.blp
+++ b/data/resources/preferences.blp
@@ -1,12 +1,7 @@
 using Gtk 4.0;
 using Adw 1;
 
-template $PreferencesWindow : Adw.PreferencesWindow {
-  default-height: 300;
-  default-width: 500;
-  modal: true;
-  search-enabled: false;
-
+template $PreferencesDialog : Adw.PreferencesDialog {
   Adw.PreferencesPage {
     Adw.PreferencesGroup dark_group {
       title: _("Appearance");

--- a/data/resources/preset-dialog.blp
+++ b/data/resources/preset-dialog.blp
@@ -17,7 +17,7 @@ template $PresetDialog : Adw.Window {
       show-start-title-buttons: false;
 
       title-widget: Adw.WindowTitle title_widget {
-        title: bind-property template.title;
+        title: bind template.title;
       };
 
       Button {

--- a/data/resources/volume-row.blp
+++ b/data/resources/volume-row.blp
@@ -33,5 +33,5 @@ Adjustment volume_adjustment {
   upper: 1;
   step-increment: 0.01;
   page-increment: 0.01;
-  value: bind-property template.volume no-sync-create bidirectional;
+  value: bind template.volume no-sync-create bidirectional;
 }

--- a/data/resources/window.blp
+++ b/data/resources/window.blp
@@ -5,7 +5,7 @@ template $BlanketWindow : Adw.ApplicationWindow {
   default-width: 520;
   default-height: 600;
   width-request: 360;
-  height-request: 200;
+  height-request: 294;
 
   Adw.Breakpoint {
     condition ("max-width: 360px")


### PR DESCRIPTION
Add `.flatpak-builder` to .gitignore

Port (hopefully) all instances of `Adw.MessageDialog` & `Gtk.MessageDialog` to `Adw.AlertDialog`

Change homepage link in metainfo and about to the [apps.gnome.org](https://apps.gnome.org) link, we already have vcs-browser, and I added a custom source code link in the about dialog.

Port `Adw.AboutWindow` to `Adw.AboutDialog`

Port `Adw.PreferencesWindow` to `Adw.PreferencesDialog`
(I removed `search-enabled: false` because it is set as false by default now)

Update `blueprint-compiler` to the latest version