### PR TITLE
appdata: `translate=no` properties

### DIFF
--- a/data/com.rafaelmardojai.Blanket.metainfo.xml.in
+++ b/data/com.rafaelmardojai.Blanket.metainfo.xml.in
@@ -39,9 +39,9 @@
   <url type="donation">https://rafaelmardojai.com/donate/</url>
   <url type="vcs-browser">https://github.com/rafaelmardojai/blanket</url>
   <!-- developer_name tag deprecated with Appstream 1.0 -->
-  <developer_name translatable="no">Rafael Mardojai CM</developer_name>
+  <developer_name translate="no">Rafael Mardojai CM</developer_name>
   <developer id="com.mardojai">
-      <name translatable="no">Rafael Mardojai CM</name>
+      <name translate="no">Rafael Mardojai CM</name>
   </developer>
   <update_contact>email_AT_rafaelmardojai.com</update_contact>
   <content_rating type="oars-1.1" />
@@ -65,7 +65,7 @@
 
   <releases>
     <release version="0.6.0" date="2022-04-13">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>App ported to GTK 4 and libadwaita</li>
           <li>User interface refinements</li>
@@ -75,7 +75,7 @@
       </description>
     </release>
     <release version="0.5.0" date="2021-09-28">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added new Presets feature</li>
           <li>Now you can toggle sounds by clicking the row</li>
@@ -97,7 +97,7 @@
       </description>
     </release>
     <release version="0.4.1" date="2021-04-26">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added Turkish translation</li>
           <li>Added Occitan translation</li>
@@ -106,7 +106,7 @@
       </description>
     </release>
     <release version="0.4.0" date="2021-04-15">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added autostart on background feature</li>
           <li>Added six new sounds</li>
@@ -125,7 +125,7 @@
       </description>
     </release>
     <release version="0.3.1" date="2020-09-12">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added Brazilian Portuguese translation</li>
           <li>Bug fixes</li>
@@ -133,7 +133,7 @@
       </description>
     </release>
     <release version="0.3.0" date="2020-09-11">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added play/pause action</li>
           <li>Added general volume control</li>
@@ -149,7 +149,7 @@
       </description>
     </release>
     <release version="0.2.0" date="2020-09-02">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Better White Noise</li>
           <li>Added Italian translation</li>
@@ -159,7 +159,7 @@
       </description>
     </release>
     <release version="0.1.0" date="2020-09-01">
-      <description translatable="no">
+      <description translate="no">
         <p>Initial release.</p>
       </description>
     </release>


### PR DESCRIPTION
It appears that the appstream project no longer supports `translatable=no` properties, and gettext extract the `translatable=no` marked strings as translatable.

I opened an issue to inform about the situation, but `translatable=no` properties are not accepted by developers. You can find the issue here: https://github.com/ximion/appstream/issues/623

Please test your script or string extraction process before merging this PR.

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html