### PR TITLE
Set symbolic icon names explicitly

### DIFF
--- a/blanket/sound.py
+++ b/blanket/sound.py
@@ -30,7 +30,7 @@ class Sound(GObject.Object):
         super().__init__()
 
         resource = f'resource:{RES_PATH}/sounds/{name}.ogg'
-        icon = 'com.rafaelmardojai.Blanket-{}'
+        icon = 'com.rafaelmardojai.Blanket-{}-symbolic'
 
         # Internal player
         self._player = None

--- a/blanket/window.py
+++ b/blanket/window.py
@@ -244,7 +244,7 @@ class BlanketWindow(Adw.ApplicationWindow):
         else:
             # Add new sound item
             item.title = _('Add…')
-            item.icon_name = 'com.rafaelmardojai.Blanket-add'
+            item.icon_name = 'com.rafaelmardojai.Blanket-add-symbolic'
 
         return item
 


### PR DESCRIPTION
Only symbolic icons are provided, so specify them explicitly instead of relying on fallback.