### PR TITLE
Remove Blueprint from manifest

### DIFF
--- a/com.rafaelmardojai.Blanket.json
+++ b/com.rafaelmardojai.Blanket.json
@@ -26,18 +26,6 @@
     ],
     "modules": [
         {
-            "name": "blueprint",
-            "buildsystem": "meson",
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://gitlab.gnome.org/GNOME/blueprint-compiler",
-                    "tag": "0.18.0",
-                    "commit": "07c9c9df9cd1b6b4454ecba21ee58211e9144a4b"
-                }
-            ]
-        },
-        {
             "name": "blanket",
             "builddir": true,
             "buildsystem": "meson",


### PR DESCRIPTION
It is now part of GNOME Software Development Kit version 49