### PR TITLE
Add D-Bus service file

### DIFF
--- a/data/com.rafaelmardojai.Blanket.desktop.in
+++ b/data/com.rafaelmardojai.Blanket.desktop.in
@@ -9,5 +9,6 @@ Type=Application
 Keywords=Concentrate;Focus;Noise;Productivity;Sleep;
 Categories=AudioVideo;Audio;GTK;
 StartupNotify=true
+DBusActivatable=true
 # Translators: Do NOT translate or transliterate this text (these are enum types)!
 X-Purism-FormFactor=Workstation;Mobile;

--- a/data/com.rafaelmardojai.Blanket.service.in
+++ b/data/com.rafaelmardojai.Blanket.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=com.rafaelmardojai.Blanket
+Exec=@bindir@/blanket --gapplication-service

--- a/data/meson.build
+++ b/data/meson.build
@@ -52,3 +52,13 @@ install_data(
   'com.rafaelmardojai.Blanket-symbolic.svg',
   install_dir: join_paths(get_option('datadir'), 'icons/hicolor/symbolic/apps')
 )
+
+service_conf = configuration_data()
+service_conf.set('bindir', join_paths(get_option('prefix'), get_option('bindir')))
+configure_file(
+  input: 'com.rafaelmardojai.Blanket.service.in',
+  output: 'com.rafaelmardojai.Blanket.service',
+  configuration: service_conf,
+  install: true,
+  install_dir: join_paths(get_option('datadir'), 'dbus-1', 'services')
+)


### PR DESCRIPTION
And mark the application as D-Bus activatable. This allows application launchers to activate it via D-Bus.

Reference:
https://specifications.freedesktop.org/desktop-entry-spec/1.3/dbus.html