### PR TITLE
README: Add Void Linux package info

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Improve focus and increase your productivity by listening to different sounds. B
 | NixOS | [`blanket`](https://search.nixos.org/packages?channel=unstable&show=blanket&from=0&size=50&sort=relevance&type=packages&query=blanket) | onny |
 | openSUSE  | [`blanket`](https://build.opensuse.org/package/show/multimedia%3Aapps/blanket) | [Michael Vetter](https://github.com/jubalh) |
 | Ubuntu (PPA) | [`Stable Releases`](https://launchpad.net/~apandada1/+archive/ubuntu/blanket), [`Daily Builds`](https://launchpad.net/~apandada1/+archive/ubuntu/blanket-daily) | [Archisman Panigrahi](https://github.com/apandada1) |
+| Void Linux | [`blanket`](https://voidlinux.org/packages/?q=blanket) | [ndpm13](https://github.com/ndpm13) |
 | MX Linux | [`blanket`](http://mxrepo.com/mx/repo/pool/main/b/blanket/) | [SwampRabbit](https://github.com/SwampRabbit) |
 
 ### Build from source


### PR DESCRIPTION
I wasn't sure what page to link to, so I copied Alpine and used a query. I hope that's alright. Linking to the actual [template](https://github.com/void-linux/void-packages/tree/master/srcpkgs/blanket) would make sense too, if you guys would prefer that just lemme know.