### PR TITLE
Update Android related project napify's name to "Blankee" and fix repo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,6 @@ If you want to support my work, you can donate me, [here you can find how](https
 ## Related Projects
 - [Blankie](https://github.com/codybrom/blankie) - Native macOS app inspired by Blanket
 - [feeltheblow](https://feeltheblow.web.app/) - Web App inspired by Blanket
-- [Soothing Noise Player](https://f-droid.org/en/packages/ie.delilahsthings.soothingloop/),  [Napify](https://github.com/itsPronay/napify) - Android apps inspired by Blanket
+- [Soothing Noise Player](https://f-droid.org/en/packages/ie.delilahsthings.soothingloop/),  [Blankee](https://github.com/itsPronay/Blankee) - Android apps inspired by Blanket
 - [Blanket Web](https://apps.roanapur.de/blanket/) - Web clone of Blanket
 - [Blanket+](https://apps.microsoft.com/detail/9P4VKD1WQQ9G?hl=neutral&gl=TR&ocid=pdpshare) - Windows version of blanket


### PR DESCRIPTION
The repository for the related Android project napify has been renamed. The previous link is no longer valid and needs to be updated. Changes needed:
- Update the project name from napify to Blankee
- Update the repository link to: https://github.com/itsPronay/blankee

cc @rafaelmardojai