### PR TITLE
Fix Misaligned "Summer Night" Volume Slider

### DIFF
--- a/data/resources/sound-item.blp
+++ b/data/resources/sound-item.blp
@@ -21,6 +21,7 @@ template $SoundItem : FlowBoxChild {
       lines: 2;
       justify: center;
       max-width-chars: 10;
+      height-request: 40;
       wrap: true;
     }
 


### PR DESCRIPTION
Closes #396.

Added "height-request: 40;" to the label in sound-item.blp file to resolve misaligned "Summer Night" volume slider.

The issue seems to be caused by the sound name having too many characters and not wrapping properly at certain aspect ratios and window sizes. This fix should prevent similar volume slider UI issues from happening for future sounds that may be added.
<img width="1920" height="1200" alt="Screenshot From 2026-06-16 19-27-42" src="https://github.com/user-attachments/assets/74d29c2a-cddc-4844-911e-fb482cf3aa6a" />
