### PR TITLE
perf: mix every sound in a single GStreamer pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ builddir/
 .flatpak-builder
 _build/
 .flatplay/
+.ruff_cache/
 
 
 #vscode

--- a/blanket/main.py
+++ b/blanket/main.py
@@ -10,6 +10,7 @@ try:
     gi.require_version("Adw", "1")
     gi.require_version("Gdk", "4.0")
     gi.require_version("Gst", "1.0")
+    gi.require_version("GstAudio", "1.0")
     gi.require_version("Gtk", "4.0")
     from gi.repository import Adw, Gio, GLib, Gst, Gtk
 

--- a/blanket/main.py
+++ b/blanket/main.py
@@ -10,7 +10,6 @@ try:
     gi.require_version("Adw", "1")
     gi.require_version("Gdk", "4.0")
     gi.require_version("Gst", "1.0")
-    gi.require_version("GstPlay", "1.0")
     gi.require_version("Gtk", "4.0")
     from gi.repository import Adw, Gio, GLib, Gst, Gtk
 
@@ -292,6 +291,7 @@ class Application(Adw.Application):
 
     def _on_shutdown(self, _app):
         self._save_settings()
+        MainPlayer.get().stop()
 
     def __get_credits_list(self, dict_):
         credits_list = []

--- a/blanket/main_player.py
+++ b/blanket/main_player.py
@@ -1,7 +1,7 @@
 # Copyright 2020-2022 Rafael Mardojai CM
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from gi.repository import Gio, GObject, Gst, Gtk
+from gi.repository import Gio, GLib, GObject, Gst, Gtk
 
 from blanket.preset import Preset
 from blanket.settings import Settings
@@ -55,6 +55,7 @@ class MainPlayer(GObject.GObject, Gio.ListModel):
         decoded into one stream and go out through a single audio sink.
         """
         self._branches = 0
+        self._detaching = set()
 
         self.pipeline = Gst.Pipeline.new("blanket")
         self.mixer = Gst.ElementFactory.make("audiomixer", "mixer")
@@ -80,7 +81,13 @@ class MainPlayer(GObject.GObject, Gio.ListModel):
         self._branches += 1
         self._sync_pipeline_state()
 
-    def branch_removed(self):
+    def branch_detaching(self, sound_bin: Gst.Bin):
+        # A branch that is being unlinked while it still runs reports a
+        # not-linked error on its way out; that one is expected
+        self._detaching.add(sound_bin)
+
+    def branch_removed(self, sound_bin: Gst.Bin):
+        self._detaching.discard(sound_bin)
         self._branches -= 1
         self._sync_pipeline_state()
 
@@ -119,8 +126,64 @@ class MainPlayer(GObject.GObject, Gio.ListModel):
         self.pipeline.set_state(Gst.State.NULL)
 
     def _on_pipeline_error(self, _bus, message: Gst.Message):
+        if self._owner(message.src, self._detaching) is not None:
+            return  # Branch on its way out of the pipeline
+
         error, debug = message.parse_error()
         print(f"Error: GStreamer playback failed: {error.message}\n{debug}")
+
+        # Every sound shares this pipeline, so a single unreadable file would
+        # otherwise take the whole mix down with it
+        sound = self._sound_of(message.src)
+        if sound is not None:
+            sound.playing = False
+
+        GLib.idle_add(self._recover)
+
+    def _recover(self):
+        """
+        Bring the pipeline back after an error
+
+        GStreamer will not resume a pipeline that reported one, so it has to go
+        through NULL and have the remaining sounds attached again.
+        """
+        # The whole pipeline goes down first: tearing the branches down one by
+        # one would block on threads the stalled mixer still holds
+        self.pipeline.set_state(Gst.State.NULL)
+
+        for sound in self:
+            player = getattr(sound, "_player", None)
+            if player is not None:
+                player.release_now()
+
+        self._branches = 0
+        self._detaching.clear()
+
+        for sound in self:
+            if sound.playing and sound.saved_volume > 0:  # type: ignore
+                sound.player.set_virtual_volume(sound.saved_volume)  # type: ignore
+
+        return GLib.SOURCE_REMOVE
+
+    def _sound_of(self, element: Gst.Object | None):
+        """Find the sound a pipeline element belongs to, if any"""
+        branches = {}
+        for sound in self:
+            player = getattr(sound, "_player", None)
+            sound_bin = player._bin if player else None
+            if sound_bin is not None:
+                branches[sound_bin] = sound
+
+        return self._owner(element, branches)
+
+    def _owner(self, element: Gst.Object | None, branches):
+        """Walk up from an element to the branch it lives in"""
+        while element is not None:
+            if element in branches:
+                return branches[element] if isinstance(branches, dict) else element
+            element = element.get_parent()
+
+        return None
 
     def mute_vol_zero(self):
         for sound in self:

--- a/blanket/main_player.py
+++ b/blanket/main_player.py
@@ -1,7 +1,7 @@
 # Copyright 2020-2022 Rafael Mardojai CM
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from gi.repository import Gio, GObject, Gtk
+from gi.repository import Gio, GObject, Gst, Gtk
 
 from blanket.preset import Preset
 from blanket.settings import Settings
@@ -44,6 +44,83 @@ class MainPlayer(GObject.GObject, Gio.ListModel):
 
         self.__add_item = GObject.GObject()  # Fake sound that adds new sounds
         self.__add_item.playing = False  # type: ignore
+
+        self._setup_pipeline()
+
+    def _setup_pipeline(self):
+        """
+        Set up the single pipeline shared by every sound
+
+        Each playing sound is a branch feeding the mixer, so all of them are
+        decoded into one stream and go out through a single audio sink.
+        """
+        self._branches = 0
+
+        self.pipeline = Gst.Pipeline.new("blanket")
+        self.mixer = Gst.ElementFactory.make("audiomixer", "mixer")
+        convert = Gst.ElementFactory.make("audioconvert", None)
+        resample = Gst.ElementFactory.make("audioresample", None)
+        sink = Gst.ElementFactory.make("autoaudiosink", None)
+
+        if not all((self.mixer, convert, resample, sink)):
+            raise RuntimeError("Could not create the GStreamer playback elements")
+
+        for element in (self.mixer, convert, resample, sink):
+            self.pipeline.add(element)
+
+        self.mixer.link(convert)  # type: ignore
+        convert.link(resample)  # type: ignore
+        resample.link(sink)  # type: ignore
+
+        bus = self.pipeline.get_bus()
+        bus.add_signal_watch()
+        bus.connect("message::error", self._on_pipeline_error)
+
+    def branch_added(self):
+        self._branches += 1
+        self._sync_pipeline_state()
+
+    def branch_removed(self):
+        self._branches -= 1
+        self._sync_pipeline_state()
+
+    def branch_offset(self) -> int:
+        """
+        Running time a branch about to be attached has to be shifted by
+
+        The mixer works in running time, so a branch joining a pipeline that
+        already advanced would be mixed in the past and dropped.
+        """
+        state = self.pipeline.get_state(0).state
+
+        if state is Gst.State.PLAYING:
+            offset = self.mixer.get_current_running_time()  # type: ignore
+        elif state is Gst.State.PAUSED:
+            offset = self.pipeline.get_start_time()
+        else:
+            return 0
+
+        return 0 if offset == Gst.CLOCK_TIME_NONE else offset
+
+    def _sync_pipeline_state(self):
+        if not self._branches:
+            # An audiomixer with no pads never prerolls, and it would leave the
+            # next attached branch stuck; keep the pipeline down instead
+            state = Gst.State.NULL
+        elif self.playing:
+            state = Gst.State.PLAYING
+        else:
+            state = Gst.State.PAUSED
+
+        self.pipeline.set_state(state)
+
+    def stop(self):
+        """Release the pipeline, called on app shutdown"""
+        self.pipeline.set_state(Gst.State.NULL)
+
+    def _on_pipeline_error(self, _bus, message: Gst.Message):
+        error, debug = message.parse_error()
+        print(f"Error: GStreamer playback failed: {error.message}\n{debug}")
 
     def mute_vol_zero(self):
         for sound in self:
@@ -101,8 +178,10 @@ class MainPlayer(GObject.GObject, Gio.ListModel):
 
     def _on_playing(self, _player, _param):
         """
-        Toggle suspension inhibition when playing
+        Toggle pipeline state and suspension inhibition when playing
         """
+        self._sync_pipeline_state()
+
         if Settings.get().inhibit_suspension:
             self._inhibit(self.playing)
 

--- a/blanket/main_player.py
+++ b/blanket/main_player.py
@@ -242,16 +242,14 @@ class MainPlayer(GObject.GObject, Gio.ListModel):
         self.pipeline.set_state(Gst.State.NULL)
 
         for sound in self:
-            player = getattr(sound, "_player", None)
-            if player is not None:
-                player.release_now()
+            sound.release_now()
 
         self._branches = 0
         self._detaching.clear()
 
         for sound in self:
             if sound.playing and sound.saved_volume > 0:
-                sound.player.volume = sound.saved_volume
+                sound.play_now()
 
         return GLib.SOURCE_REMOVE
 

--- a/blanket/main_player.py
+++ b/blanket/main_player.py
@@ -28,7 +28,7 @@ class MainPlayer(GObject.GObject, Gio.ListModel):
     volume: float = GObject.Property(type=float, default=0)  # type: ignore
 
     @classmethod
-    def get(cls):
+    def get(cls) -> "MainPlayer":
         """Return an active instance of MainPlayer."""
         if cls._instance is None:
             cls._instance = MainPlayer()
@@ -103,31 +103,95 @@ class MainPlayer(GObject.GObject, Gio.ListModel):
             from_val,
         )
 
-    def branch_added(self):
-        self._branches += 1
-        self._sync_pipeline_state()
+    def attach_sound_bin(
+        self,
+        sound_bin: Gst.Bin,
+    ) -> Gst.Pad | None:
+        """Attach a sound player to the pipeline mixer."""
+        if self.mixer is None:
+            return None
 
-    def branch_detaching(self, sound_bin: Gst.Bin):
+        self.pipeline.add(sound_bin)
+
+        mixer_pad = self.mixer.request_pad_simple("sink_%u")
+        src_pad = sound_bin.get_static_pad("src")
+
+        if mixer_pad is None or src_pad is None:
+            return None
+
+        # Shift the branch to where the mixer already is, or it would produce
+        # buffers the mixer considers long past and drops.
+        src_pad.set_offset(self._get_branch_offset())
+        src_pad.link(mixer_pad)
+
+        self._branches += 1  # Increment branch count
+        self._sync_pipeline_state()
+        sound_bin.sync_state_with_parent()
+
+        return mixer_pad
+
+    def detach_sound_bin(self, sound_bin: Gst.Bin, mixer_pad: Gst.Pad) -> None:
+        """Detach a sound player from the pipeline mixer."""
+
         # A branch that is being unlinked while it still runs reports a
-        # not-linked error on its way out; that one is expected
+        # not-linked error on its way out; that one is expected.
         self._detaching.add(sound_bin)
 
-    def branch_removed(self, sound_bin: Gst.Bin):
-        self._detaching.discard(sound_bin)
-        self._branches -= 1
+        state: Gst.State = self.pipeline.get_state(0).state  # type: ignore
+        if state is not Gst.State.PLAYING:
+            # Nothing is streaming, so a blocking probe would never be called,
+            # just destroy the branch immediately.
+            self._destroy_branch(sound_bin, mixer_pad)
+            return
+
+        # Block the branch before tearing it down, so the mixer never sees a
+        # half-removed pad.
+        if pad := sound_bin.get_static_pad("src"):
+            pad.add_probe(
+                Gst.PadProbeType.IDLE,
+                lambda _pad, _info: self._on_branch_blocked(sound_bin, mixer_pad),
+            )
+
+    def _on_branch_blocked(self, sound_bin: Gst.Bin, mixer_pad: Gst.Pad):
+        # States cannot be changed from a streaming thread
+        GLib.idle_add(self._destroy_branch, sound_bin, mixer_pad)
+        return Gst.PadProbeReturn.REMOVE
+
+    def _destroy_branch(self, sound_bin: Gst.Bin, mixer_pad: Gst.Pad):
+        """Destroy a sound branch and remove it from the pipeline."""
+        if self.mixer is None:
+            return
+
+        # Stop the branch before unlinking it, so it does not push into a pad
+        # that is already gone.
+        sound_bin.set_state(Gst.State.NULL)
+        if pad := sound_bin.get_static_pad("src"):
+            pad.unlink(mixer_pad)
+
+        self.mixer.release_request_pad(mixer_pad)
+        self.pipeline.remove(sound_bin)
+
+        self._detaching.discard(sound_bin)  # Remove from detaching set
+        self._branches -= 1  # Decrement branch count
         self._sync_pipeline_state()
 
-    def branch_offset(self) -> int:
+        return GLib.SOURCE_REMOVE
+
+    def _get_branch_offset(self) -> int:
         """
-        Running time a branch about to be attached has to be shifted by
+        A branch about to be attached has to be shifted to match the mixer's
+        current position.
 
         The mixer works in running time, so a branch joining a pipeline that
         already advanced would be mixed in the past and dropped.
         """
-        state = self.pipeline.get_state(0).state
+        if not self.mixer:
+            return 0
+
+        state: Gst.State = self.pipeline.get_state(0).state  # type: ignore
 
         if state is Gst.State.PLAYING:
-            offset = self.mixer.get_current_running_time()  # type: ignore
+            offset = self.mixer.get_current_running_time()
         elif state is Gst.State.PAUSED:
             offset = self.pipeline.get_start_time()
         else:

--- a/blanket/main_player.py
+++ b/blanket/main_player.py
@@ -1,7 +1,7 @@
 # Copyright 2020-2022 Rafael Mardojai CM
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from gi.repository import Gio, GLib, GObject, Gst, Gtk
+from gi.repository import Gio, GLib, GObject, Gst, GstAudio, Gtk
 
 from blanket.preset import Preset
 from blanket.settings import Settings
@@ -61,21 +61,47 @@ class MainPlayer(GObject.GObject, Gio.ListModel):
         self.mixer = Gst.ElementFactory.make("audiomixer", "mixer")
         convert = Gst.ElementFactory.make("audioconvert", None)
         resample = Gst.ElementFactory.make("audioresample", None)
+        volume = Gst.ElementFactory.make("volume", None)
         sink = Gst.ElementFactory.make("autoaudiosink", None)
 
-        if not all((self.mixer, convert, resample, sink)):
+        if not all((self.mixer, convert, resample, volume, sink)):
             raise RuntimeError("Could not create the GStreamer playback elements")
 
-        for element in (self.mixer, convert, resample, sink):
-            self.pipeline.add(element)
+        for element in (self.mixer, convert, resample, volume, sink):
+            self.pipeline.add(element)  # type: ignore
 
         self.mixer.link(convert)  # type: ignore
         convert.link(resample)  # type: ignore
-        resample.link(sink)  # type: ignore
+        resample.link(volume)  # type: ignore
+        volume.link(sink)  # type: ignore
 
         bus = self.pipeline.get_bus()
         bus.add_signal_watch()
         bus.connect("message::error", self._on_pipeline_error)
+
+        # Make main player control sink volume
+        volume.bind_property(  # type: ignore
+            "volume",
+            self,
+            "volume",
+            GObject.BindingFlags.BIDIRECTIONAL,
+            self._vol_to_gst,
+            self._vol_to_ui,
+        )
+
+    def _vol_to_gst(self, _bind, from_val: float) -> float:
+        return GstAudio.StreamVolume.convert_volume(
+            GstAudio.StreamVolumeFormat.LINEAR,
+            GstAudio.StreamVolumeFormat.CUBIC,
+            from_val,
+        )
+
+    def _vol_to_ui(self, _bind, from_val: float) -> float:
+        return GstAudio.StreamVolume.convert_volume(
+            GstAudio.StreamVolumeFormat.CUBIC,
+            GstAudio.StreamVolumeFormat.LINEAR,
+            from_val,
+        )
 
     def branch_added(self):
         self._branches += 1
@@ -160,8 +186,8 @@ class MainPlayer(GObject.GObject, Gio.ListModel):
         self._detaching.clear()
 
         for sound in self:
-            if sound.playing and sound.saved_volume > 0:  # type: ignore
-                sound.player.set_virtual_volume(sound.saved_volume)  # type: ignore
+            if sound.playing and sound.saved_volume > 0:
+                sound.player.volume = sound.saved_volume
 
         return GLib.SOURCE_REMOVE
 

--- a/blanket/player.py
+++ b/blanket/player.py
@@ -22,9 +22,8 @@ class Player:
 
     def __init__(self, sound):
         self.sound = sound
-        # Create a var to save saved volume
-        self.saved_volume = 0.0
 
+        self._volume_value = 0.0
         self._bin = None
         self._convert = None
         self._volume = None
@@ -32,36 +31,29 @@ class Player:
         self._looping = False
         self._release_id = 0
 
-        # Connect mainplayer volume signal
-        self.volume_hdlr = MainPlayer.get().connect(
-            "notify::volume", self._on_main_volume_changed
-        )
+    @property
+    def volume(self) -> float:
+        return self._volume_value
 
-    def set_virtual_volume(self, volume: float):
-        # Get last saved sound volume
-        self.saved_volume = volume
-        # Multiply sound volume with mainplayer volume
-        volume = self.saved_volume * MainPlayer.get().volume
+    @volume.setter
+    def volume(self, value: float):
+        self._volume_value = value
 
-        if volume > 0:
+        if value > 0:
             self._cancel_release()
             self._attach()
-            self._volume.props.volume = volume  # type: ignore
+            self._volume.props.volume = value  # type: ignore
         else:
             # An inaudible sound keeps no decoder around, but dragging a slider
             # across zero should not tear the branch down and rebuild it
+            if self._volume:
+                self._volume.props.volume = 0.0  # type: ignore
             self._schedule_release()
 
     def remove(self):
         # Drop the branch from the pipeline
         self._cancel_release()
         self._detach()
-        # Disconnect main player signals
-        MainPlayer.get().disconnect(self.volume_hdlr)
-
-    def _on_main_volume_changed(self, _player, _volume):
-        # Set volume again when mainplayer volume changes
-        self.set_virtual_volume(self.saved_volume)
 
     """
     Branch handling

--- a/blanket/player.py
+++ b/blanket/player.py
@@ -5,6 +5,12 @@ from gi.repository import GLib, Gst
 
 from blanket.main_player import MainPlayer
 
+# Seconds an inaudible sound keeps its decoder before it is released
+RELEASE_DELAY = 5
+# A sound whose duration is not known yet cannot be looped, so wait for it
+LOOP_RETRY_INTERVAL = 200
+LOOP_RETRIES = 25
+
 
 class Player:
     """
@@ -24,6 +30,7 @@ class Player:
         self._volume = None
         self._mixer_pad = None
         self._looping = False
+        self._release_id = 0
 
         # Connect mainplayer volume signal
         self.volume_hdlr = MainPlayer.get().connect(
@@ -33,17 +40,21 @@ class Player:
     def set_virtual_volume(self, volume: float):
         # Get last saved sound volume
         self.saved_volume = volume
+        # Multiply sound volume with mainplayer volume
+        volume = self.saved_volume * MainPlayer.get().volume
 
-        if self.saved_volume > 0:
+        if volume > 0:
+            self._cancel_release()
             self._attach()
-            # Multiply sound volume with mainplayer volume
-            self._volume.props.volume = self.saved_volume * MainPlayer.get().volume  # type: ignore
+            self._volume.props.volume = volume  # type: ignore
         else:
-            # A silent sound keeps no pipeline around
-            self._detach()
+            # An inaudible sound keeps no decoder around, but dragging a slider
+            # across zero should not tear the branch down and rebuild it
+            self._schedule_release()
 
     def remove(self):
         # Drop the branch from the pipeline
+        self._cancel_release()
         self._detach()
         # Disconnect main player signals
         MainPlayer.get().disconnect(self.volume_hdlr)
@@ -56,13 +67,28 @@ class Player:
     Branch handling
     """
 
+    def _schedule_release(self):
+        if self._bin is None or self._release_id:
+            return
+
+        self._release_id = GLib.timeout_add_seconds(RELEASE_DELAY, self._release)
+
+    def _cancel_release(self):
+        if self._release_id:
+            GLib.source_remove(self._release_id)
+            self._release_id = 0
+
+    def _release(self):
+        self._release_id = 0
+        self._detach()
+        return GLib.SOURCE_REMOVE
+
     def _attach(self):
         if self._bin is not None:
             return
 
         player = MainPlayer.get()
 
-        self._bin = Gst.Bin.new(f"sound-{self.sound.name}")
         decoder = Gst.ElementFactory.make("uridecodebin", None)
         convert = Gst.ElementFactory.make("audioconvert", None)
         # audiomixer does not convert between formats, so a sound recorded at
@@ -72,7 +98,8 @@ class Player:
         volume = Gst.ElementFactory.make("volume", None)
 
         if not all((decoder, convert, resample, caps, volume)):
-            raise RuntimeError("Could not create the GStreamer sound elements")
+            print("Error: could not create the GStreamer elements for a sound")
+            return
 
         decoder.props.uri = self.sound.uri  # type: ignore
         # Every branch has to reach the mixer in the same format, and mixing at
@@ -81,16 +108,21 @@ class Player:
             "audio/x-raw,format=F32LE,rate=44100,channels=2,layout=interleaved"
         )
 
+        # Left unnamed on purpose: a name taken from the sound would clash with
+        # the bin of a branch that is still being torn down, and with a custom
+        # sound sharing the name of a built-in one
+        sound_bin = Gst.Bin.new(None)
         for element in (decoder, convert, resample, caps, volume):
-            self._bin.add(element)
+            sound_bin.add(element)
 
         convert.link(resample)  # type: ignore
         resample.link(caps)  # type: ignore
         caps.link(volume)  # type: ignore
 
+        self._bin = sound_bin
         self._convert = convert
         self._volume = volume
-        self._bin.add_pad(
+        sound_bin.add_pad(
             Gst.GhostPad.new("src", volume.get_static_pad("src"))  # type: ignore
         )
         decoder.connect("pad-added", self._on_pad_added)  # type: ignore
@@ -107,16 +139,32 @@ class Player:
         player.branch_added()
         self._bin.sync_state_with_parent()
 
-    def _detach(self):
+    def release_now(self):
+        """Tear the branch down without waiting for the stream to go idle"""
+        self._cancel_release()
+
         if self._bin is None:
             return
 
         sound_bin, mixer_pad = self._bin, self._mixer_pad
+        MainPlayer.get().branch_detaching(sound_bin)
+        self._forget_branch()
+        self._destroy_branch(sound_bin, mixer_pad)
+
+    def _forget_branch(self):
         self._bin = None
         self._convert = None
         self._volume = None
         self._mixer_pad = None
         self._looping = False
+
+    def _detach(self):
+        if self._bin is None:
+            return
+
+        sound_bin, mixer_pad = self._bin, self._mixer_pad
+        MainPlayer.get().branch_detaching(sound_bin)
+        self._forget_branch()
 
         state = MainPlayer.get().pipeline.get_state(0).state
         if state is not Gst.State.PLAYING:
@@ -140,11 +188,13 @@ class Player:
     def _destroy_branch(self, sound_bin: Gst.Bin, mixer_pad):
         player = MainPlayer.get()
 
+        # Stop the branch before unlinking it, so it does not push into a pad
+        # that is already gone
+        sound_bin.set_state(Gst.State.NULL)
         sound_bin.get_static_pad("src").unlink(mixer_pad)  # type: ignore
         player.mixer.release_request_pad(mixer_pad)  # type: ignore
-        sound_bin.set_state(Gst.State.NULL)
         player.pipeline.remove(sound_bin)
-        player.branch_removed()
+        player.branch_removed(sound_bin)
 
         return GLib.SOURCE_REMOVE
 
@@ -172,33 +222,47 @@ class Player:
         src_pad.add_probe(Gst.PadProbeType.EVENT_DOWNSTREAM, self._on_branch_event)
 
     def _on_first_buffer(self, _pad, _info):
-        GLib.idle_add(self._start_loop)
+        GLib.idle_add(self._start_loop, 0)
         return Gst.PadProbeReturn.REMOVE
 
-    def _start_loop(self):
+    def _start_loop(self, attempt: int):
         if self._bin is None or self._looping:
             return GLib.SOURCE_REMOVE
 
-        if not self._seek(flush=True):
-            return GLib.SOURCE_CONTINUE
+        if self._seek(flush=True):
+            self._looping = True
+        else:
+            self._retry_loop(self._start_loop, attempt)
 
-        self._looping = True
         return GLib.SOURCE_REMOVE
 
-    def _restart_loop(self):
+    def _restart_loop(self, attempt: int):
         if self._bin is None:
             return GLib.SOURCE_REMOVE
 
         if not self._seek(flush=False):
-            return GLib.SOURCE_CONTINUE
+            self._retry_loop(self._restart_loop, attempt)
 
         return GLib.SOURCE_REMOVE
+
+    def _retry_loop(self, callback, attempt: int):
+        """
+        Try again later when the duration is not known yet
+
+        Retrying from the idle callback itself would only spin the main loop,
+        and a sound whose duration never resolves would spin it forever.
+        """
+        if attempt >= LOOP_RETRIES:
+            print(f"Error: could not loop {self.sound.name}, its duration is unknown")
+            return
+
+        GLib.timeout_add(LOOP_RETRY_INTERVAL, callback, attempt + 1)
 
     def _on_branch_event(self, _pad, info: Gst.PadProbeInfo):
         event = info.get_event()
 
         if event and event.type is Gst.EventType.SEGMENT_DONE:
-            GLib.idle_add(self._restart_loop)
+            GLib.idle_add(self._restart_loop, 0)
             return Gst.PadProbeReturn.DROP
 
         if event and event.type is Gst.EventType.EOS:

--- a/blanket/player.py
+++ b/blanket/player.py
@@ -1,18 +1,16 @@
 # Copyright 2020-2022 Rafael Mardojai CM
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from typing import Callable
+
 from gi.repository import GLib, Gst
 
-from blanket.main_player import MainPlayer
-
-# Seconds an inaudible sound keeps its decoder before it is released
-RELEASE_DELAY = 5
 # A sound whose duration is not known yet cannot be looped, so wait for it
 LOOP_RETRY_INTERVAL = 200
 LOOP_RETRIES = 25
 
 
-class Player:
+class Player(Gst.Bin):
     """
     Playback of a single sound, as a branch of the shared pipeline
 
@@ -20,71 +18,11 @@ class Player:
     silent sounds cost neither a decoder nor its threads.
     """
 
-    def __init__(self, sound):
-        self.sound = sound
+    def __init__(self, sound, **kwargs):
+        super().__init__(**kwargs)
 
-        self._volume_value = 0.0
-        self._bin = None
-        self._convert = None
-        self._volume = None
-        self._mixer_pad = None
+        self._sound = sound
         self._looping = False
-        self._release_id = 0
-
-    @property
-    def volume(self) -> float:
-        return self._volume_value
-
-    @volume.setter
-    def volume(self, value: float):
-        self._volume_value = value
-
-        if value > 0:
-            self._cancel_release()
-            self._attach()
-            self._volume.props.volume = value  # type: ignore
-        else:
-            # An inaudible sound keeps no decoder around, but dragging a slider
-            # across zero should not tear the branch down and rebuild it
-            if self._volume:
-                self._volume.props.volume = 0.0  # type: ignore
-            self._schedule_release()
-
-    def remove(self):
-        # Drop the branch from the pipeline
-        self._cancel_release()
-        self._detach()
-
-    """
-    Branch handling
-    """
-
-    def release_now(self):
-        """Tear the branch down without waiting for the stream to go idle"""
-        self._cancel_release()
-        self._detach()
-
-    def _schedule_release(self):
-        if self._bin is None or self._release_id:
-            return
-
-        self._release_id = GLib.timeout_add_seconds(RELEASE_DELAY, self._release)
-
-    def _cancel_release(self):
-        if self._release_id:
-            GLib.source_remove(self._release_id)
-            self._release_id = 0
-
-    def _release(self):
-        self._release_id = 0
-        self._detach()
-        return GLib.SOURCE_REMOVE
-
-    def _attach(self):
-        if self._bin is not None:
-            return
-
-        player = MainPlayer.get()
 
         decoder = Gst.ElementFactory.make("uridecodebin", None)
         convert = Gst.ElementFactory.make("audioconvert", None)
@@ -98,47 +36,35 @@ class Player:
             print("Error: could not create the GStreamer elements for a sound")
             return
 
-        decoder.props.uri = self.sound.uri  # type: ignore
+        decoder.props.uri = sound.uri  # type: ignore
+
         # Every branch has to reach the mixer in the same format, and mixing at
-        # the rate the sounds already are in keeps the resamplers idle
+        # the rate the sounds already are in keeps the resamplers idle.
         caps.props.caps = Gst.Caps.from_string(  # type: ignore
             "audio/x-raw,format=F32LE,rate=44100,channels=2,layout=interleaved"
         )
 
-        # Left unnamed on purpose: a name taken from the sound would clash with
-        # the bin of a branch that is still being torn down, and with a custom
-        # sound sharing the name of a built-in one
-        sound_bin = Gst.Bin.new(None)
         for element in (decoder, convert, resample, caps, volume):
-            sound_bin.add(element)
+            self.add(element)
 
         convert.link(resample)
         resample.link(caps)
         caps.link(volume)
 
-        self._bin = sound_bin
         self._convert = convert
         self._volume = volume
 
         if vol_pad := volume.get_static_pad("src"):
-            sound_bin.add_pad(Gst.GhostPad.new("src", vol_pad))
+            self.add_pad(Gst.GhostPad.new("src", vol_pad))
         decoder.connect("pad-added", self._on_pad_added)
 
-        self._mixer_pad = player.attach_sound_bin(self._bin)
-        if self._mixer_pad is None:
-            return
+    @property
+    def volume(self) -> float:
+        return self._volume.props.volume  # type: ignore
 
-    def _detach(self):
-        if self._bin is None or self._mixer_pad is None:
-            return
-
-        MainPlayer.get().detach_sound_bin(self._bin, self._mixer_pad)
-
-        self._bin = None
-        self._convert = None
-        self._volume = None
-        self._mixer_pad = None
-        self._looping = False
+    @volume.setter
+    def volume(self, value: float):
+        self._volume.props.volume = value  # type: ignore
 
     """
     Loop handling
@@ -147,15 +73,12 @@ class Player:
     for it. The matching event is caught as it leaves the branch instead.
     """
 
-    def _on_pad_added(self, _decoder, pad: Gst.Pad):
-        if self._bin is None or self._convert is None:
-            return
-
+    def _on_pad_added(self, _decoder: Gst.Element, pad: Gst.Pad):
         sink_pad = self._convert.get_static_pad("sink")
         if sink_pad and not sink_pad.is_linked():
             pad.link(sink_pad)
 
-        src_pad = self._bin.get_static_pad("src")
+        src_pad = self.get_static_pad("src")
         if src_pad is None:
             return
 
@@ -163,12 +86,12 @@ class Player:
         src_pad.add_probe(Gst.PadProbeType.BUFFER, self._on_first_buffer)
         src_pad.add_probe(Gst.PadProbeType.EVENT_DOWNSTREAM, self._on_branch_event)
 
-    def _on_first_buffer(self, _pad, _info):
+    def _on_first_buffer(self, _pad: Gst.Pad, _info: Gst.PadProbeInfo):
         GLib.idle_add(self._start_loop, 0)
         return Gst.PadProbeReturn.REMOVE
 
     def _start_loop(self, attempt: int):
-        if self._bin is None or self._looping:
+        if self._looping:
             return GLib.SOURCE_REMOVE
 
         if self._seek(flush=True):
@@ -179,15 +102,12 @@ class Player:
         return GLib.SOURCE_REMOVE
 
     def _restart_loop(self, attempt: int):
-        if self._bin is None:
-            return GLib.SOURCE_REMOVE
-
         if not self._seek(flush=False):
             self._retry_loop(self._restart_loop, attempt)
 
         return GLib.SOURCE_REMOVE
 
-    def _retry_loop(self, callback, attempt: int):
+    def _retry_loop(self, callback: Callable[[int], bool], attempt: int):
         """
         Try again later when the duration is not known yet
 
@@ -195,7 +115,7 @@ class Player:
         and a sound whose duration never resolves would spin it forever.
         """
         if attempt >= LOOP_RETRIES:
-            print(f"Error: could not loop {self.sound.name}, its duration is unknown")
+            print(f"Error: could not loop {self._sound.name}, its duration is unknown")
             return
 
         GLib.timeout_add(LOOP_RETRY_INTERVAL, callback, attempt + 1)
@@ -214,12 +134,9 @@ class Player:
         return Gst.PadProbeReturn.OK
 
     def _seek(self, flush: bool) -> bool:
-        if self._bin is None:
-            return False
-
         # The segment has to be given an explicit end: seeking before the
-        # duration is known would leave an empty one, looping on itself
-        known, duration = self._bin.query_duration(Gst.Format.TIME)
+        # duration is known would leave an empty one, looping on itself.
+        known, duration = self.query_duration(Gst.Format.TIME)
         if not known or duration <= 0:
             return False
 
@@ -227,7 +144,7 @@ class Player:
         if flush:
             flags |= Gst.SeekFlags.FLUSH
 
-        return self._bin.seek(
+        return self.seek(
             1.0,
             Gst.Format.TIME,
             flags,

--- a/blanket/player.py
+++ b/blanket/player.py
@@ -1,103 +1,232 @@
 # Copyright 2020-2022 Rafael Mardojai CM
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from gi.repository import Gst, GstPlay
+from gi.repository import GLib, Gst
 
 from blanket.main_player import MainPlayer
 
 
-class Player(GstPlay.Play):
+class Player:
     """
-    GstPlay.Play with modifications
-    """
+    Playback of a single sound, as a branch of the shared pipeline
 
-    __gtype_name__ = "SoundPlayer"
+    The branch is only attached to the mixer while the sound is audible, so
+    silent sounds cost neither a decoder nor its threads.
+    """
 
     def __init__(self, sound):
-        super().__init__()
-
         self.sound = sound
         # Create a var to save saved volume
         self.saved_volume = 0.0
-        # Always start with volume in 0
-        self.set_volume(0)
 
-        # Set Sound.uri as player uri
-        self.set_uri(self.sound.uri)
-        self.name = self.sound.name
-
-        # Loop setup
-        self.prerolled = False
-        self.pipeline = self.get_pipeline()
-        bus = self.pipeline.get_bus()
-        bus.add_signal_watch()
-        bus.connect("message", self._on_bus_message)
+        self._bin = None
+        self._convert = None
+        self._volume = None
+        self._mixer_pad = None
+        self._looping = False
 
         # Connect mainplayer volume signal
         self.volume_hdlr = MainPlayer.get().connect(
             "notify::volume", self._on_main_volume_changed
         )
-        # Connect mainplayer muted signal
-        self.playing_hdlr = MainPlayer.get().connect(
-            "notify::playing", self._on_playing_changed
-        )
-
-        # Connect volume-changed signal
-        self.connect("notify::volume", self._on_volume_changed)
 
     def set_virtual_volume(self, volume: float):
         # Get last saved sound volume
         self.saved_volume = volume
-        # Multiply sound volume with mainplayer volume
-        volume = self.saved_volume * MainPlayer.get().volume
-        # Set final volume to player
-        self.set_volume(volume)
+
+        if self.saved_volume > 0:
+            self._attach()
+            # Multiply sound volume with mainplayer volume
+            self._volume.props.volume = self.saved_volume * MainPlayer.get().volume  # type: ignore
+        else:
+            # A silent sound keeps no pipeline around
+            self._detach()
 
     def remove(self):
-        # Stop player
-        self.stop()
+        # Drop the branch from the pipeline
+        self._detach()
         # Disconnect main player signals
         MainPlayer.get().disconnect(self.volume_hdlr)
-        MainPlayer.get().disconnect(self.playing_hdlr)
-
-    def _on_playing_changed(self, _player, _volume):
-        if not self.__vol_zero():
-            if MainPlayer.get().playing:
-                self.play()
-            else:
-                self.pause()
-
-    def _on_volume_changed(self, _player, _volume):
-        # Fix external changes to player volume
-        volume = self.saved_volume * MainPlayer.get().volume
-        if volume > 0 and self.get_volume() == 0.0:
-            self.set_volume(volume)
-            return
-        # Only play if volume > 0
-        if self.__vol_zero():
-            self.pause()
-        elif MainPlayer.get().playing:
-            self.play()
 
     def _on_main_volume_changed(self, _player, _volume):
-        if not self.__vol_zero(self.sound.saved_volume):
-            # Set volume again when mainplayer volume changes
-            self.set_virtual_volume(self.saved_volume)
+        # Set volume again when mainplayer volume changes
+        self.set_virtual_volume(self.saved_volume)
 
-    def _on_bus_message(self, _bus, message: Gst.Message):
-        if message:
-            if message.type is Gst.MessageType.SEGMENT_DONE:
-                self.pipeline.seek_simple(Gst.Format.TIME, Gst.SeekFlags.SEGMENT, 0)
+    """
+    Branch handling
+    """
 
-            if message.type is Gst.MessageType.ASYNC_DONE:
-                if not self.prerolled:
-                    self.pipeline.seek_simple(
-                        Gst.Format.TIME, Gst.SeekFlags.FLUSH | Gst.SeekFlags.SEGMENT, 0
-                    )
-                    self.prerolled = True
+    def _attach(self):
+        if self._bin is not None:
+            return
 
-            return True
+        player = MainPlayer.get()
 
-    def __vol_zero(self, volume: float | None = None):
-        volume = volume if volume else self.get_volume()
-        return True if volume == 0 else False
+        self._bin = Gst.Bin.new(f"sound-{self.sound.name}")
+        decoder = Gst.ElementFactory.make("uridecodebin", None)
+        convert = Gst.ElementFactory.make("audioconvert", None)
+        # audiomixer does not convert between formats, so a sound recorded at
+        # another rate has to be resampled before it reaches the mixer
+        resample = Gst.ElementFactory.make("audioresample", None)
+        caps = Gst.ElementFactory.make("capsfilter", None)
+        volume = Gst.ElementFactory.make("volume", None)
+
+        if not all((decoder, convert, resample, caps, volume)):
+            raise RuntimeError("Could not create the GStreamer sound elements")
+
+        decoder.props.uri = self.sound.uri  # type: ignore
+        # Every branch has to reach the mixer in the same format, and mixing at
+        # the rate the sounds already are in keeps the resamplers idle
+        caps.props.caps = Gst.Caps.from_string(  # type: ignore
+            "audio/x-raw,format=F32LE,rate=44100,channels=2,layout=interleaved"
+        )
+
+        for element in (decoder, convert, resample, caps, volume):
+            self._bin.add(element)
+
+        convert.link(resample)  # type: ignore
+        resample.link(caps)  # type: ignore
+        caps.link(volume)  # type: ignore
+
+        self._convert = convert
+        self._volume = volume
+        self._bin.add_pad(
+            Gst.GhostPad.new("src", volume.get_static_pad("src"))  # type: ignore
+        )
+        decoder.connect("pad-added", self._on_pad_added)  # type: ignore
+
+        player.pipeline.add(self._bin)
+        self._mixer_pad = player.mixer.request_pad_simple("sink_%u")  # type: ignore
+
+        src_pad = self._bin.get_static_pad("src")
+        # Shift the branch to where the mixer already is, or it would produce
+        # buffers the mixer considers long past and drops
+        src_pad.set_offset(player.branch_offset())  # type: ignore
+        src_pad.link(self._mixer_pad)  # type: ignore
+
+        player.branch_added()
+        self._bin.sync_state_with_parent()
+
+    def _detach(self):
+        if self._bin is None:
+            return
+
+        sound_bin, mixer_pad = self._bin, self._mixer_pad
+        self._bin = None
+        self._convert = None
+        self._volume = None
+        self._mixer_pad = None
+        self._looping = False
+
+        state = MainPlayer.get().pipeline.get_state(0).state
+        if state is not Gst.State.PLAYING:
+            # Nothing is streaming, so a blocking probe would never be called
+            self._destroy_branch(sound_bin, mixer_pad)
+            return
+
+        # Block the branch before tearing it down, so the mixer never sees a
+        # half-removed pad
+        pad = sound_bin.get_static_pad("src")
+        pad.add_probe(  # type: ignore
+            Gst.PadProbeType.IDLE,
+            lambda _pad, _info: self._on_branch_blocked(sound_bin, mixer_pad),
+        )
+
+    def _on_branch_blocked(self, sound_bin: Gst.Bin, mixer_pad):
+        # States cannot be changed from a streaming thread
+        GLib.idle_add(self._destroy_branch, sound_bin, mixer_pad)
+        return Gst.PadProbeReturn.REMOVE
+
+    def _destroy_branch(self, sound_bin: Gst.Bin, mixer_pad):
+        player = MainPlayer.get()
+
+        sound_bin.get_static_pad("src").unlink(mixer_pad)  # type: ignore
+        player.mixer.release_request_pad(mixer_pad)  # type: ignore
+        sound_bin.set_state(Gst.State.NULL)
+        player.pipeline.remove(sound_bin)
+        player.branch_removed()
+
+        return GLib.SOURCE_REMOVE
+
+    """
+    Loop handling
+
+    The sound has no sink of its own, so the pipeline never posts SEGMENT_DONE
+    for it. The matching event is caught as it leaves the branch instead.
+    """
+
+    def _on_pad_added(self, _decoder, pad: Gst.Pad):
+        if self._bin is None or self._convert is None:
+            return
+
+        sink_pad = self._convert.get_static_pad("sink")
+        if sink_pad and not sink_pad.is_linked():
+            pad.link(sink_pad)
+
+        src_pad = self._bin.get_static_pad("src")
+        if src_pad is None:
+            return
+
+        # Seeking before the caps are negotiated fails, so wait for data
+        src_pad.add_probe(Gst.PadProbeType.BUFFER, self._on_first_buffer)
+        src_pad.add_probe(Gst.PadProbeType.EVENT_DOWNSTREAM, self._on_branch_event)
+
+    def _on_first_buffer(self, _pad, _info):
+        GLib.idle_add(self._start_loop)
+        return Gst.PadProbeReturn.REMOVE
+
+    def _start_loop(self):
+        if self._bin is None or self._looping:
+            return GLib.SOURCE_REMOVE
+
+        if not self._seek(flush=True):
+            return GLib.SOURCE_CONTINUE
+
+        self._looping = True
+        return GLib.SOURCE_REMOVE
+
+    def _restart_loop(self):
+        if self._bin is None:
+            return GLib.SOURCE_REMOVE
+
+        if not self._seek(flush=False):
+            return GLib.SOURCE_CONTINUE
+
+        return GLib.SOURCE_REMOVE
+
+    def _on_branch_event(self, _pad, info: Gst.PadProbeInfo):
+        event = info.get_event()
+
+        if event and event.type is Gst.EventType.SEGMENT_DONE:
+            GLib.idle_add(self._restart_loop)
+            return Gst.PadProbeReturn.DROP
+
+        if event and event.type is Gst.EventType.EOS:
+            # Letting it through would end the whole pipeline
+            return Gst.PadProbeReturn.DROP
+
+        return Gst.PadProbeReturn.OK
+
+    def _seek(self, flush: bool) -> bool:
+        if self._bin is None:
+            return False
+
+        # The segment has to be given an explicit end: seeking before the
+        # duration is known would leave an empty one, looping on itself
+        known, duration = self._bin.query_duration(Gst.Format.TIME)
+        if not known or duration <= 0:
+            return False
+
+        flags = Gst.SeekFlags.SEGMENT
+        if flush:
+            flags |= Gst.SeekFlags.FLUSH
+
+        return self._bin.seek(
+            1.0,
+            Gst.Format.TIME,
+            flags,
+            Gst.SeekType.SET,
+            0,
+            Gst.SeekType.SET,
+            duration,
+        )

--- a/blanket/player.py
+++ b/blanket/player.py
@@ -59,6 +59,11 @@ class Player:
     Branch handling
     """
 
+    def release_now(self):
+        """Tear the branch down without waiting for the stream to go idle"""
+        self._cancel_release()
+        self._detach()
+
     def _schedule_release(self):
         if self._bin is None or self._release_id:
             return
@@ -89,7 +94,7 @@ class Player:
         caps = Gst.ElementFactory.make("capsfilter", None)
         volume = Gst.ElementFactory.make("volume", None)
 
-        if not all((decoder, convert, resample, caps, volume)):
+        if not decoder or not convert or not resample or not caps or not volume:
             print("Error: could not create the GStreamer elements for a sound")
             return
 
@@ -107,88 +112,33 @@ class Player:
         for element in (decoder, convert, resample, caps, volume):
             sound_bin.add(element)
 
-        convert.link(resample)  # type: ignore
-        resample.link(caps)  # type: ignore
-        caps.link(volume)  # type: ignore
+        convert.link(resample)
+        resample.link(caps)
+        caps.link(volume)
 
         self._bin = sound_bin
         self._convert = convert
         self._volume = volume
-        sound_bin.add_pad(
-            Gst.GhostPad.new("src", volume.get_static_pad("src"))  # type: ignore
-        )
-        decoder.connect("pad-added", self._on_pad_added)  # type: ignore
 
-        player.pipeline.add(self._bin)
-        self._mixer_pad = player.mixer.request_pad_simple("sink_%u")  # type: ignore
+        if vol_pad := volume.get_static_pad("src"):
+            sound_bin.add_pad(Gst.GhostPad.new("src", vol_pad))
+        decoder.connect("pad-added", self._on_pad_added)
 
-        src_pad = self._bin.get_static_pad("src")
-        # Shift the branch to where the mixer already is, or it would produce
-        # buffers the mixer considers long past and drops
-        src_pad.set_offset(player.branch_offset())  # type: ignore
-        src_pad.link(self._mixer_pad)  # type: ignore
-
-        player.branch_added()
-        self._bin.sync_state_with_parent()
-
-    def release_now(self):
-        """Tear the branch down without waiting for the stream to go idle"""
-        self._cancel_release()
-
-        if self._bin is None:
+        self._mixer_pad = player.attach_sound_bin(self._bin)
+        if self._mixer_pad is None:
             return
 
-        sound_bin, mixer_pad = self._bin, self._mixer_pad
-        MainPlayer.get().branch_detaching(sound_bin)
-        self._forget_branch()
-        self._destroy_branch(sound_bin, mixer_pad)
+    def _detach(self):
+        if self._bin is None or self._mixer_pad is None:
+            return
 
-    def _forget_branch(self):
+        MainPlayer.get().detach_sound_bin(self._bin, self._mixer_pad)
+
         self._bin = None
         self._convert = None
         self._volume = None
         self._mixer_pad = None
         self._looping = False
-
-    def _detach(self):
-        if self._bin is None:
-            return
-
-        sound_bin, mixer_pad = self._bin, self._mixer_pad
-        MainPlayer.get().branch_detaching(sound_bin)
-        self._forget_branch()
-
-        state = MainPlayer.get().pipeline.get_state(0).state
-        if state is not Gst.State.PLAYING:
-            # Nothing is streaming, so a blocking probe would never be called
-            self._destroy_branch(sound_bin, mixer_pad)
-            return
-
-        # Block the branch before tearing it down, so the mixer never sees a
-        # half-removed pad
-        pad = sound_bin.get_static_pad("src")
-        pad.add_probe(  # type: ignore
-            Gst.PadProbeType.IDLE,
-            lambda _pad, _info: self._on_branch_blocked(sound_bin, mixer_pad),
-        )
-
-    def _on_branch_blocked(self, sound_bin: Gst.Bin, mixer_pad):
-        # States cannot be changed from a streaming thread
-        GLib.idle_add(self._destroy_branch, sound_bin, mixer_pad)
-        return Gst.PadProbeReturn.REMOVE
-
-    def _destroy_branch(self, sound_bin: Gst.Bin, mixer_pad):
-        player = MainPlayer.get()
-
-        # Stop the branch before unlinking it, so it does not push into a pad
-        # that is already gone
-        sound_bin.set_state(Gst.State.NULL)
-        sound_bin.get_static_pad("src").unlink(mixer_pad)  # type: ignore
-        player.mixer.release_request_pad(mixer_pad)  # type: ignore
-        player.pipeline.remove(sound_bin)
-        player.branch_removed(sound_bin)
-
-        return GLib.SOURCE_REMOVE
 
     """
     Loop handling

--- a/blanket/sound.py
+++ b/blanket/sound.py
@@ -83,7 +83,9 @@ class Sound(GObject.Object):
     def remove(self):
         """Remove sound if it is custom"""
         if self.custom:
-            self.player.set_virtual_volume(0)
+            if self._player is not None:
+                self._player.remove()
+                self._player = None
             Settings.get().remove_custom_audio(self.name)
 
     def _playing_changed(self, _object, _pspec):

--- a/blanket/sound.py
+++ b/blanket/sound.py
@@ -34,6 +34,7 @@ class Sound(GObject.Object):
 
         # Internal player
         self._player = None
+        self._removed = False
 
         # Sound properties
         self.name = name
@@ -48,9 +49,13 @@ class Sound(GObject.Object):
             self.playing = True
 
         # Connect mainplayer preset-changed signal
-        MainPlayer.get().connect("preset-changed", self._on_preset_changed)
+        self._preset_hdlr = MainPlayer.get().connect(
+            "preset-changed", self._on_preset_changed
+        )
         # Connect mainplayer reset-volumes signal
-        MainPlayer.get().connect("reset-volumes", self._on_reset_volumes)
+        self._reset_hdlr = MainPlayer.get().connect(
+            "reset-volumes", self._on_reset_volumes
+        )
 
     @property
     def player(self) -> Player:
@@ -65,6 +70,9 @@ class Sound(GObject.Object):
 
     @saved_volume.setter
     def saved_volume(self, volume: float):
+        if self._removed:
+            return
+
         volume = round(volume, 2)
         self.player.set_virtual_volume(volume)
         Settings.get().set_sound_volume(self.name, volume)
@@ -83,12 +91,23 @@ class Sound(GObject.Object):
     def remove(self):
         """Remove sound if it is custom"""
         if self.custom:
+            self._removed = True
+
             if self._player is not None:
                 self._player.remove()
                 self._player = None
+
+            # A removed sound still reachable from a signal closure would
+            # otherwise come back to life on the next preset change
+            MainPlayer.get().disconnect(self._preset_hdlr)
+            MainPlayer.get().disconnect(self._reset_hdlr)
+
             Settings.get().remove_custom_audio(self.name)
 
     def _playing_changed(self, _object, _pspec):
+        if self._removed:
+            return
+
         # Toggle player mute state
         if self.playing:
             if self.saved_volume > 0:

--- a/blanket/sound.py
+++ b/blanket/sound.py
@@ -1,12 +1,15 @@
 # Copyright 2020-2021 Rafael Mardojai CM
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from gi.repository import GObject
+from gi.repository import GLib, GObject, Gst
 
 from blanket.define import RES_PATH
 from blanket.main_player import MainPlayer
 from blanket.player import Player
 from blanket.settings import Settings
+
+# Seconds an inaudible sound keeps its decoder before it is released
+RELEASE_DELAY = 5
 
 
 class Sound(GObject.Object):
@@ -33,7 +36,9 @@ class Sound(GObject.Object):
         icon = "com.rafaelmardojai.Blanket-{}-symbolic"
 
         # Internal player
-        self._player = None
+        self._player: Player | None = None
+        self._mixer_pad: Gst.Pad | None = None
+        self._release_id: int = 0
         self._removed = False
 
         # Sound properties
@@ -57,15 +62,8 @@ class Sound(GObject.Object):
             "reset-volumes", self._on_reset_volumes
         )
 
-    @property
-    def player(self) -> Player:
-        """Internal player"""
-        if self._player is None:
-            self._player = Player(self)
-        return self._player
-
     @GObject.Property(type=float)
-    def saved_volume(self) -> float:  # type: ignore
+    def saved_volume(self) -> float:
         return Settings.get().get_sound_volume(self.name)
 
     @saved_volume.setter
@@ -74,7 +72,10 @@ class Sound(GObject.Object):
             return
 
         volume = round(volume, 2)
-        self.player.volume = volume
+
+        if self._player:
+            self._player.volume = volume
+
         Settings.get().set_sound_volume(self.name, volume)
 
         if volume != 0 and not self.playing:
@@ -92,10 +93,8 @@ class Sound(GObject.Object):
         """Remove sound if it is custom"""
         if self.custom:
             self._removed = True
-
-            if self._player is not None:
-                self._player.remove()
-                self._player = None
+            self._cancel_release()
+            self._detach()
 
             # A removed sound still reachable from a signal closure would
             # otherwise come back to life on the next preset change
@@ -110,13 +109,16 @@ class Sound(GObject.Object):
 
         # Toggle player mute state
         if self.playing:
-            if self.saved_volume > 0:
-                self.player.volume = self.saved_volume
-            else:
-                self.player.volume = 0.5
+            if self.saved_volume == 0:
                 self.saved_volume = 0.5
+
+            self._player_up()
+
+            if self._player:
+                self._player.volume = self.saved_volume
+
         else:
-            self.player.volume = 0
+            self._player_down()
 
         self.saved_mute = not self.playing  # Save playing state
 
@@ -127,3 +129,57 @@ class Sound(GObject.Object):
     def _on_reset_volumes(self, _player):
         self.saved_volume = 0.0
         self.playing = False
+
+    """
+    Branch handling
+    """
+
+    def release_now(self):
+        """Tear the branch down without waiting for the stream to go idle"""
+        self._cancel_release()
+        self._detach()
+
+    def play_now(self):
+        """Play the sound immediately"""
+        self._player_up()
+
+    def _player_up(self):
+        self._cancel_release()
+        self._attach()
+
+    def _player_down(self):
+        if self._player is not None:
+            self._player.volume = 0
+            self._schedule_release()
+
+    def _schedule_release(self):
+        if self._player is None or self._release_id:
+            return
+
+        self._release_id = GLib.timeout_add_seconds(RELEASE_DELAY, self._release)
+
+    def _cancel_release(self):
+        if self._release_id:
+            GLib.source_remove(self._release_id)
+            self._release_id = 0
+
+    def _release(self):
+        self._release_id = 0
+        self._detach()
+        return GLib.SOURCE_REMOVE
+
+    def _detach(self):
+        if self._player is None or self._mixer_pad is None:
+            return
+
+        MainPlayer.get().detach_sound_bin(self._player, self._mixer_pad)
+
+        self._mixer_pad = None
+        self._player = None
+
+    def _attach(self):
+        if self._player is not None:
+            return
+
+        self._player = Player(self)
+        self._mixer_pad = MainPlayer.get().attach_sound_bin(self._player)

--- a/blanket/sound.py
+++ b/blanket/sound.py
@@ -74,7 +74,7 @@ class Sound(GObject.Object):
             return
 
         volume = round(volume, 2)
-        self.player.set_virtual_volume(volume)
+        self.player.volume = volume
         Settings.get().set_sound_volume(self.name, volume)
 
         if volume != 0 and not self.playing:
@@ -111,12 +111,12 @@ class Sound(GObject.Object):
         # Toggle player mute state
         if self.playing:
             if self.saved_volume > 0:
-                self.player.set_virtual_volume(self.saved_volume)
+                self.player.volume = self.saved_volume
             else:
-                self.player.set_virtual_volume(0.5)
+                self.player.volume = 0.5
                 self.saved_volume = 0.5
         else:
-            self.player.set_virtual_volume(0)
+            self.player.volume = 0
 
         self.saved_mute = not self.playing  # Save playing state
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ typeCheckingMode = "standard"
 
 [dependency-groups]
 dev = [
-    "basedpyright>=1.31.0",
-    "pygobject-stubs>=2.13.0",
+    "pygobject-stubs>=2.17.0",
     "ruff>=0.12.5",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1,27 +1,14 @@
 version = 1
 revision = 2
-requires-python = ">=3.10"
-
-[[package]]
-name = "basedpyright"
-version = "1.31.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nodejs-wheel-binaries" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/20/23/6dc0df43c62fdec401b1ec3aea698ba50c5abfca25259e9f0208b34d7abe/basedpyright-1.31.0.tar.gz", hash = "sha256:900a573a525a0f66f884075c2a98711bb9478e44dc60ffdf182ef681bf8e2c76", size = 22062384, upload-time = "2025-07-16T11:37:29.189Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/85/cb46707458c514ae959fe139135d8f7231d95faf1c383a56979a3436b965/basedpyright-1.31.0-py3-none-any.whl", hash = "sha256:d7460ddcd3a2332b1c3fd738735d18bf2966d49aed67237efa1f19635199d414", size = 11538999, upload-time = "2025-07-16T11:37:26.446Z" },
-]
+requires-python = ">=3.11"
 
 [[package]]
 name = "blanket"
-version = "0.7.0"
+version = "0.8.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]
 dev = [
-    { name = "basedpyright" },
     { name = "pygobject-stubs" },
     { name = "ruff" },
 ]
@@ -30,32 +17,54 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "basedpyright", specifier = ">=1.31.0" },
-    { name = "pygobject-stubs", specifier = ">=2.13.0" },
+    { name = "pygobject-stubs", specifier = ">=2.17.0" },
     { name = "ruff", specifier = ">=0.12.5" },
 ]
 
 [[package]]
-name = "nodejs-wheel-binaries"
-version = "22.17.0"
+name = "pycairo"
+version = "1.29.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d3/86/8962d1d24ff480f4dd31871f42c8e0d8e2c851cd558a07ee689261d310ab/nodejs_wheel_binaries-22.17.0.tar.gz", hash = "sha256:529142012fb8fd20817ef70e2ef456274df4f49933292e312c8bbc7285af6408", size = 8068, upload-time = "2025-06-29T20:24:25.002Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/7c/ab4637b028d9ee12280ab9342f28310e613d5ca30c4d72d2aebeaa6a4969/pycairo-1.29.1.tar.gz", hash = "sha256:4fbd26b4af24c9787d84cf5448e34eb8dca064b732479aaecd03109520eebd5f", size = 666272, upload-time = "2026-08-07T08:45:50.095Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/53/b942c6da4ff6f87a315033f6ff6fed8fd3c22047d7ff5802badaa5dfc2c2/nodejs_wheel_binaries-22.17.0-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:6545a6f6d2f736d9c9e2eaad7e599b6b5b2d8fd4cbd2a1df0807cbcf51b9d39b", size = 51003554, upload-time = "2025-06-29T20:23:47.042Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/b7/7184a9ad2364912da22f2fe021dc4a3301721131ef7759aeb4a1f19db0b4/nodejs_wheel_binaries-22.17.0-py2.py3-none-macosx_11_0_x86_64.whl", hash = "sha256:4bea5b994dd87c20f8260031ea69a97c3d282e2d4472cc8908636a313a830d00", size = 51936848, upload-time = "2025-06-29T20:23:52.064Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/7a/0ea425147b8110b8fd65a6c21cfd3bd130cdec7766604361429ef870d799/nodejs_wheel_binaries-22.17.0-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:885508615274a22499dd5314759c1cf96ba72de03e6485d73b3e5475e7f12662", size = 57925230, upload-time = "2025-06-29T20:23:56.81Z" },
-    { url = "https://files.pythonhosted.org/packages/23/5f/10a3f2ac08a839d065d9ccfd6d9df66bc46e100eaf87a8a5cf149eb3fb8e/nodejs_wheel_binaries-22.17.0-py2.py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90f38ce034a602bcab534d55cbe0390521e73e5dcffdd1c4b34354b932172af2", size = 58457829, upload-time = "2025-06-29T20:24:01.945Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/a4/d2ca331e16eef0974eb53702df603c54f77b2a7e2007523ecdbf6cf61162/nodejs_wheel_binaries-22.17.0-py2.py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5eed087855b644c87001fe04036213193963ccd65e7f89949e9dbe28e7743d9b", size = 59778054, upload-time = "2025-06-29T20:24:07.14Z" },
-    { url = "https://files.pythonhosted.org/packages/be/2b/04e0e7f7305fe2ba30fd4610bfb432516e0f65379fe6c2902f4b7b1ad436/nodejs_wheel_binaries-22.17.0-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:715f413c81500f0770ea8936ef1fc2529b900da8054cbf6da67cec3ee308dc76", size = 60830079, upload-time = "2025-06-29T20:24:12.21Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/67/12070b24b88040c2d694883f3dcb067052f748798f4c63f7c865769a5747/nodejs_wheel_binaries-22.17.0-py2.py3-none-win_amd64.whl", hash = "sha256:51165630493c8dd4acfe1cae1684b76940c9b03f7f355597d55e2d056a572ddd", size = 40117877, upload-time = "2025-06-29T20:24:17.51Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/ec/53ac46af423527c23e40c7343189f2bce08a8337efedef4d8a33392cee23/nodejs_wheel_binaries-22.17.0-py2.py3-none-win_arm64.whl", hash = "sha256:fae56d172227671fccb04461d3cd2b26a945c6c7c7fc29edb8618876a39d8b4a", size = 38865278, upload-time = "2025-06-29T20:24:21.065Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/83/d2dfb322cc3acc583aa6e8e601e7c320108804f3f3c677383f23a0de8624/pycairo-1.29.1-cp311-cp311-win32.whl", hash = "sha256:50da6e8eb1525f216e564b3e634b19ede5465080d4fa813416ed45a69b3f6605", size = 751309, upload-time = "2026-08-07T08:46:07.317Z" },
+    { url = "https://files.pythonhosted.org/packages/34/e6/f09d1c0ca4a887aea020774c59adabc04b7e1d2f00287ef48473540001e5/pycairo-1.29.1-cp311-cp311-win_amd64.whl", hash = "sha256:73a364341ce6b382200d13cfdf814f8ea50a8a2e0f8280c2d2e7dfb3ba52edcf", size = 845463, upload-time = "2026-08-07T08:46:09.287Z" },
+    { url = "https://files.pythonhosted.org/packages/69/a6/84415dce82c4865169847acc2de7895a1463956569383f17cb39e89f1287/pycairo-1.29.1-cp311-cp311-win_arm64.whl", hash = "sha256:59eb4a6d1101834a7ba2c7a8096fccd54eb8514d8189f896b4a8e24a19cfa1f0", size = 694560, upload-time = "2026-08-07T08:46:10.657Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f6/b6a2e016cf0df97b2cd094c228c9303af21d626993607d8ea750ea8b704b/pycairo-1.29.1-cp312-cp312-win32.whl", hash = "sha256:cf25a97a15bedd0cdabee5b18652de45eff70b4a7999416ed18dcee2144d17f5", size = 751363, upload-time = "2026-08-07T08:46:12.545Z" },
+    { url = "https://files.pythonhosted.org/packages/69/7e/7be1346df5ab8cd7f748f2d17d25d61f34550cfd141f60e8319e9c70df87/pycairo-1.29.1-cp312-cp312-win_amd64.whl", hash = "sha256:839cd8c98e1933426d8959168b466901b398bf4867454451023b93d91030cca9", size = 846004, upload-time = "2026-08-07T08:46:14.067Z" },
+    { url = "https://files.pythonhosted.org/packages/04/97/40966895bc12319ff3173cbb5d7876149a8e90e99bbf3b70e4af492c73a9/pycairo-1.29.1-cp312-cp312-win_arm64.whl", hash = "sha256:7cb6279cf0a7951ae9aaa21c6a0adff0fce62c0a68797b6a26a54f9a0859ad4d", size = 694560, upload-time = "2026-08-07T08:46:15.839Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/26191cac03e8c0d957856839736ee9fb45c6d4ae68c30393895558f1f7ad/pycairo-1.29.1-cp313-cp313-win32.whl", hash = "sha256:4506a15f0dcd9d65b2706f417f8e5633e1456867d5cf272dc69c0b48e2302842", size = 750753, upload-time = "2026-08-07T08:46:17.523Z" },
+    { url = "https://files.pythonhosted.org/packages/81/ba/3499ae0f6f8be6d55ef5db620a60693b4ef925b710890bf66c17aeff036e/pycairo-1.29.1-cp313-cp313-win_amd64.whl", hash = "sha256:859f5f29d7c30fc28dbc5ce91eb30a45e0b7e447a7bd738c231dd7f9be368d1a", size = 844528, upload-time = "2026-08-07T08:46:19.1Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c1/f83f25aab64418d4de6527cbf951988fc9449020e416113e3a7a4ad7e7b8/pycairo-1.29.1-cp313-cp313-win_arm64.whl", hash = "sha256:0c6159117680798da1457404b648e69b0a0eb23597b22f8a97315eaeea19f917", size = 693588, upload-time = "2026-08-07T08:46:21.087Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ef/87408894ebef901c2accde14dcacfbdbd9bc9abe617039ee6ff382847b75/pycairo-1.29.1-cp314-cp314-win32.whl", hash = "sha256:7222587a4ae1674287c17d10d1c42c4219914f7ef64cac4b2fb995df4f7918cb", size = 767089, upload-time = "2026-08-07T08:46:25.92Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/13/aef0ea29661a2fa0cadb3cbb470b514d439efe763cafc956c8b740ad1480/pycairo-1.29.1-cp314-cp314-win_amd64.whl", hash = "sha256:f635a60b7525661b562061e4b1635670b804d1efc9c7f40796c2fa14b24c3ddf", size = 872072, upload-time = "2026-08-07T08:46:27.605Z" },
+    { url = "https://files.pythonhosted.org/packages/68/95/fc823a255ed1967ec5bda7243247a2fb484faf868c0cd1ffd1425ae515e8/pycairo-1.29.1-cp314-cp314-win_arm64.whl", hash = "sha256:b5db545cc8e59fe9bb68039db86c5ebcf9d1e6417695d0d2cb5530e67d925af9", size = 719612, upload-time = "2026-08-07T08:46:29.127Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/25/4cd521dd9e0f280930717bb93499c50008a6f14b312649d34a54dbd1df71/pycairo-1.29.1-cp314-cp314t-win_amd64.whl", hash = "sha256:3836feabfaf35ef9c502234c5924f3b2db935b6c55d8850ed190b3a58ab3b4ca", size = 874492, upload-time = "2026-08-07T08:46:22.695Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/ee/006df2caa60f2df242b9baf13ab95d4575b47acabc54f3ab6d757d3a9691/pycairo-1.29.1-cp314-cp314t-win_arm64.whl", hash = "sha256:85127fb834a8a37a550fa5c684a4c49fc546b465a64ac8df94d7728914a56279", size = 721461, upload-time = "2026-08-07T08:46:24.104Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ec/4466cce6363c07759d04f9481f81d84a6dc506b735e795c193eb63e4f9ef/pycairo-1.29.1-cp315-cp315-win_amd64.whl", hash = "sha256:5c51bd98d2190841389845deae8243479393c1f2d9423de85e9fb4c95afebc10", size = 872007, upload-time = "2026-08-07T08:46:34.392Z" },
+    { url = "https://files.pythonhosted.org/packages/92/03/214ee759a86bd821e306c2071aef0de9c201020e7690f9cf165fa2d61d42/pycairo-1.29.1-cp315-cp315-win_arm64.whl", hash = "sha256:e923875c96cfe935d632de50aeebf49db7dffdd23f9042587c3f34af7596868e", size = 719602, upload-time = "2026-08-07T08:46:35.802Z" },
+    { url = "https://files.pythonhosted.org/packages/14/df/b163de08eb5307eacda6ee98001a4b920df8432d49f1da9b8d1c8d0342f5/pycairo-1.29.1-cp315-cp315t-win_amd64.whl", hash = "sha256:12515e71e2f17db8c40911ff089c23c465f92ddbabb89cd01304f275030c80ec", size = 874517, upload-time = "2026-08-07T08:46:30.779Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/04/81a13cde3c6685186fd79770d619c9b861d51de7450975618a85e8676772/pycairo-1.29.1-cp315-cp315t-win_arm64.whl", hash = "sha256:e5dde8dc08d92ad6935d1a45ff6ea71ea6d5739ed08dbf8677313935f94d5c6d", size = 721459, upload-time = "2026-08-07T08:46:32.19Z" },
 ]
 
 [[package]]
-name = "pygobject-stubs"
-version = "2.13.0"
+name = "pygobject"
+version = "3.56.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d1/3f/d9a43ab76ad7a2d6d3a2968513b76760100c33128c6a0d3ac996dfb37c77/pygobject_stubs-2.13.0.tar.gz", hash = "sha256:4f608f5dfe10c3173f0a082416e22e27b693743c2a635de245c78a51458e2ab6", size = 870193, upload-time = "2025-03-13T21:22:38.156Z" }
+dependencies = [
+    { name = "pycairo" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/61/978c5fbca34f10a90df362502fbb5a005637909e7b5a0e9212349ea9d010/pygobject-3.56.3.tar.gz", hash = "sha256:12760e4a0e3d04b6eb95e06f7a27e362c826d567ea613373a92c003b6c70d2d6", size = 1411853, upload-time = "2026-05-08T20:46:39.904Z" }
+
+[[package]]
+name = "pygobject-stubs"
+version = "2.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygobject" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/be/bf49399ad2e788121f595903a56447d4b778d67acbb01ecfc1c6d5cf91f6/pygobject_stubs-2.17.0.tar.gz", hash = "sha256:66884d26974dd7fb99a8bc5972b5bdeb4b7399ecc7ac53913a6cafa6ab21491f", size = 1010510, upload-time = "2026-03-20T17:08:59.656Z" }
 
 [[package]]
 name = "ruff"
@@ -80,4 +89,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3e/b9/053d6445dc7544fb6594785056d8ece61daae7214859ada4a152ad56b6e0/ruff-0.12.5-py3-none-win32.whl", hash = "sha256:dfeb2627c459b0b78ca2bbdc38dd11cc9a0a88bf91db982058b26ce41714ffa9", size = 11751575, upload-time = "2025-07-24T13:26:30.835Z" },
     { url = "https://files.pythonhosted.org/packages/bc/0f/ab16e8259493137598b9149734fec2e06fdeda9837e6f634f5c4e35916da/ruff-0.12.5-py3-none-win_amd64.whl", hash = "sha256:ae0d90cf5f49466c954991b9d8b953bd093c32c27608e409ae3564c63c5306a5", size = 12882273, upload-time = "2025-07-24T13:26:32.929Z" },
     { url = "https://files.pythonhosted.org/packages/00/db/c376b0661c24cf770cb8815268190668ec1330eba8374a126ceef8c72d55/ruff-0.12.5-py3-none-win_arm64.whl", hash = "sha256:48cdbfc633de2c5c37d9f090ba3b352d1576b0015bfc3bc98eaf230275b7e805", size = 11951564, upload-time = "2025-07-24T13:26:34.994Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
 ]


### PR DESCRIPTION
Closes #314, closes #342.

## The problem

Blanket creates one `GstPlay.Play` per sound. Each of those carries a whole
`playbin`: typefind, decodebin with its multiqueue, an audio queue, a converter
chain, its own audio sink and its own main loop thread. So every enabled sound
costs roughly seven threads and one PulseAudio/PipeWire stream, and the only
part of that which genuinely has to be per sound is the decoding.

Measured on the released 0.8.0 with four sounds enabled, the per-thread CPU
breakdown over 10 s was: `multiqueue*:src` 4.6%, `aqueue:src` 2.2%,
`threaded-ml` (the audio client main loop) 2.0%, `oggdemux*:sink` 0.6%.

## The change

Sounds become branches of a single pipeline. Each branch decodes into a shared
`audiomixer`, and the mix leaves through one audio sink.

```
uridecodebin -> audioconvert -> audioresample -> capsfilter -> volume -.
uridecodebin -> audioconvert -> audioresample -> capsfilter -> volume -+-> audiomixer -> audioconvert -> audioresample -> autoaudiosink
```

A branch is attached only while the sound is actually audible — its own volume
and the master volume both count — and released a few seconds after it goes
silent, so a disabled sound no longer holds a decoder open, which the previous
code did since it only paused the player. The delay matters: dragging a volume
slider across zero would otherwise rebuild the decoder on every intermediate
value, and toggling a sound off and straight back on keeps its position. When no
sound is left, the pipeline goes down to `NULL`.

Because every sound now shares one bus, a single failing sound would take the
whole mix down with it. So an error is traced back to the sound it came from:
that sound is switched off, and the pipeline is brought back through `NULL` with
the remaining sounds re-attached, instead of everything going silent at once.

## Results

Same four enabled sounds, same machine, steady state measured over 45 s:

| | before | after |
|---|---|---|
| threads | 40 | 25 |
| CPU | 14.8% | 10.6% |
| RSS | 171 MB | 158 MB |

In an isolated A/B harness driving both designs in one process with the sounds
looping, the gap widens with the number of sounds: at 10 sounds, 73 threads /
35.8% CPU before against 34 threads / 20.5% after.

## Implementation notes

Four things here are not obvious, and each one is a silent failure if missed:

- **A branch has no sink of its own**, so the pipeline never posts
  `SEGMENT_DONE` for it and looping cannot be driven from the bus. The looping
  watches the matching *event* on the branch ghost pad instead. `EOS` is dropped
  at the same place — letting it through ends the whole pipeline.
- **The segment needs an explicit end.** Seeking with `seek_simple` before the
  duration is known leaves an empty segment that loops on itself, never feeds
  the mixer, and stalls the preroll of the entire pipeline. This presents as the
  app being silent while the UI still reports playing.
- **A branch joining a pipeline that already advanced must be shifted** by the
  running time of the mixer, otherwise the mixer takes its buffers for long past
  ones and drops them.
- **An `audiomixer` with no pads never prerolls**, and it leaves the next branch
  attached to it stuck, hence dropping the pipeline to `NULL` when the last
  branch goes away.

`audiomixer` does not convert between formats, so each branch reaches it through
a resampler and a fixed caps filter. Mixing at 44100 Hz rather than 48000 matters
measurably — every bundled sound but `train.ogg` is already 44100/stereo, so the
resamplers stay idle.

## Relation to #313 and #409

This targets the rework the maintainer sketched in #313 / the `playback-rework`
branch, which has been idle since 2022.

I also tried the existing #409, which builds on that branch, to avoid
duplicating work. Two things stand in its way, and I mention them only so the
overlap is clear: it removes `blanket/player.py` without dropping it from
`blanket/meson.build`, so the build fails at configure time; and after patching
that locally it starts up with 51 threads and produces no audio at all while
reporting `PlaybackStatus: Playing`. It uses `adder`, which in my measurements
stalls outright once about ten branches are attached — `audiomixer` handles the
dynamic attach/detach that Blanket needs, which is why this PR uses it.

## Testing

Verified against a build of this branch, with a scripted harness driving the
real `Sound`/`MainPlayer` objects:

- four sounds play and loop, including the short 7.2 s one;
- silencing a sound releases its branch, re-enabling it plays again;
- global pause freezes positions and holds branches, resume continues;
- master volume multiplies through to the branch volume;
- silencing everything drops the pipeline to `NULL` (14 threads), and enabling a
  sound afterwards starts playback again;
- removing a custom sound releases its branch and leaves the rest playing;
- a double toggle and a volume slider dragged across zero leave the sound
  playing, rather than colliding with the branch still being torn down;
- a master volume of zero releases every decoder, and restoring it resumes;
- an unreadable file switches its own sound off while the others keep playing;
- a removed custom sound does not come back on the next preset change.

`ruff format --check` and `ruff check` are clean on the touched files.

## Known trade-off

Sounds now share one output stream, so per-sound routing to different output
devices is no longer possible. That was mentioned as a nice-to-have in #314; it
is the direct cost of collapsing the streams, and also what makes #82 tractable.
