### PR TITLE
mpris: add missing mandatory properties and always reply on D-Bus

### DIFF
--- a/blanket/mpris.py
+++ b/blanket/mpris.py
@@ -72,8 +72,15 @@ class Server:
                 invocation.return_value(variant)
             else:
                 invocation.return_value(None)
+        except GLib.Error as e:
+            # Always answer the caller. A D-Bus method that neither returns a
+            # value nor an error leaves the peer blocked until its own timeout
+            # expires (forever, for peers that set an infinite one).
+            invocation.return_gerror(e)
         except Exception as e:
-            print(e)
+            invocation.return_error_literal(
+                Gio.dbus_error_quark(), Gio.DBusError.FAILED, str(e)
+            )
 
 
 class MPRIS(Server):
@@ -110,8 +117,11 @@ class MPRIS(Server):
             </method>
             <property name="CanQuit" type="b" access="read" />
             <property name="CanRaise" type="b" access="read" />
+            <property name="HasTrackList" type="b" access="read"/>
             <property name="Identity" type="s" access="read"/>
             <property name="DesktopEntry" type="s" access="read"/>
+            <property name="SupportedUriSchemes" type="as" access="read"/>
+            <property name="SupportedMimeTypes" type="as" access="read"/>
         </interface>
         <interface name="org.mpris.MediaPlayer2.Player">
             <method name="Next"/>
@@ -120,10 +130,18 @@ class MPRIS(Server):
             <method name="Play"/>
             <method name="Pause"/>
             <method name="Stop"/>
+            <signal name="Seeked">
+                <arg name="Position" type="x"/>
+            </signal>
             <property name="PlaybackStatus" type="s" access="read"/>
             <property name="Metadata" type="a{sv}" access="read">
             </property>
+            <property name="Position" type="x" access="read"/>
+            <property name="Rate" type="d" access="readwrite"/>
+            <property name="MinimumRate" type="d" access="read"/>
+            <property name="MaximumRate" type="d" access="read"/>
             <property name="Volume" type="d" access="readwrite"/>
+            <property name="CanSeek" type="b" access="read"/>
             <property name="CanGoNext" type="b" access="read"/>
             <property name="CanGoPrevious" type="b" access="read"/>
             <property name="CanPlay" type="b" access="read"/>
@@ -198,6 +216,11 @@ class MPRIS(Server):
             "CanPause",
         ]:
             return GLib.Variant("b", True)
+        elif property_name == "HasTrackList":
+            return GLib.Variant("b", False)
+        elif property_name in ["SupportedUriSchemes", "SupportedMimeTypes"]:
+            # Blanket only plays its own bundled sounds; it opens no URIs.
+            return GLib.Variant("as", [])
         elif property_name == "CanGoNext":
             return GLib.Variant("b", MainPlayer.get().can_next)
         elif property_name == "CanGoPrevious":
@@ -212,19 +235,43 @@ class MPRIS(Server):
             return GLib.Variant("a{sv}", self.__metadata)
         elif property_name == "Volume":
             return GLib.Variant("d", MainPlayer.get().volume)
-        else:
+        elif property_name == "Position":
+            # Blanket loops ambient sounds and has no seekable timeline.
+            return GLib.Variant("x", 0)
+        elif property_name in ["Rate", "MinimumRate", "MaximumRate"]:
+            return GLib.Variant("d", 1.0)
+        elif property_name == "CanSeek":
             return GLib.Variant("b", False)
+        else:
+            raise GLib.Error.new_literal(
+                Gio.dbus_error_quark(),
+                f"No such property '{property_name}'",
+                Gio.DBusError.UNKNOWN_PROPERTY,
+            )
 
     def GetAll(self, interface):
         ret = {}
         if interface == self.__MPRIS_IFACE:
-            for property_name in ["CanQuit", "CanRaise", "Identity", "DesktopEntry"]:
+            for property_name in [
+                "CanQuit",
+                "CanRaise",
+                "HasTrackList",
+                "Identity",
+                "DesktopEntry",
+                "SupportedUriSchemes",
+                "SupportedMimeTypes",
+            ]:
                 ret[property_name] = self.Get(interface, property_name)
         elif interface == self.__MPRIS_PLAYER_IFACE:
             for property_name in [
                 "PlaybackStatus",
                 "Metadata",
+                "Position",
+                "Rate",
+                "MinimumRate",
+                "MaximumRate",
                 "Volume",
+                "CanSeek",
                 "CanGoNext",
                 "CanGoPrevious",
                 "CanPlay",


### PR DESCRIPTION
Fixes #367

## What

Blanket's MPRIS interfaces are missing eight mandatory properties, and `Get()` answers unknown properties with a boolean instead of an error. Separately, the D-Bus server wrapper never replies at all when a handler raises.

Missing from `org.mpris.MediaPlayer2`: `HasTrackList`, `SupportedUriSchemes`, `SupportedMimeTypes`.
Missing from `org.mpris.MediaPlayer2.Player`: `Position`, `Rate`, `MinimumRate`, `MaximumRate`, `CanSeek` (plus the `Seeked` signal).

## Why

#367 reports this from the Astal/Vala side — their D-Bus proxy crashes unpacking the variant, because a property declared nowhere returns `b false` from the catch-all in `Get()`.

I hit the same bug from a different direction, with a more severe symptom: **Waybar rendering nothing at all** while Blanket was running.

1. Blanket doesn't declare `Position`, so `Get("Position")` falls through to the catch-all and returns a boolean where the spec requires `x` (int64):

   ```
   $ busctl --user get-property org.mpris.MediaPlayer2.Blanket \
       /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player Position
   b false
   ```

2. `playerctld`, proxying for the active player, receives that malformed reply and never responds to its own caller:

   ```
   $ busctl --user get-property org.mpris.MediaPlayer2.playerctld \
       /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player Position
   Failed to get property Position ...: Connection timed out
   ```

3. Waybar's `mpris` module calls `playerctl_player_get_position()` synchronously from inside the GTK main-loop dispatch. The main loop never returns, so the bar never draws a frame — process alive, layer surface created and sized, zero buffers ever attached.

Waybar and playerctld each have their own robustness problem here, but Blanket is the root cause: a spec-correct player makes the whole chain work.

## Verification

A control player publishing a correct `Position` (type `x`) shows playerctld forwards fine when the upstream player behaves:

| Active player | `playerctld` `Position` |
| --- | --- |
| Blanket (unpatched) | hangs, caller times out |
| Spec-correct control player | `x 4242424`, instant |
| **Blanket with this patch** | **`x 0`, instant** |

Direct queries against the patched server:

```
root.HasTrackList         -> b false
root.SupportedUriSchemes  -> as 0
root.SupportedMimeTypes   -> as 0
player.Position           -> x 0
player.Rate/Min/MaxRate   -> d 1
player.CanSeek            -> b false
player.PlaybackStatus     -> s "Playing"
NoSuchProperty            -> org.freedesktop.DBus.Error.UnknownProperty   (was: b false)
GetAll (root)             -> 7 properties
GetAll (player)           -> 13 properties, Position present as int64
```

## Notes on the choices

- `Position` returns `0`. Blanket loops ambient sounds and has no seekable timeline, so `CanSeek` is `false` and the `Seeked` signal is declared but never emitted — which is what the spec expects of a non-seekable player.
- `Rate`/`MinimumRate`/`MaximumRate` are all `1.0`. With min == max, any `Set` on `Rate` is correctly a no-op, so `Set()` needed no change.
- `SupportedUriSchemes`/`SupportedMimeTypes` are empty arrays: Blanket only plays its own bundled sounds and opens no URIs.
- The `GLib.Error` branch in `on_method_call` is kept separate from the generic `Exception` branch so handlers can raise a specific D-Bus error (as `Get` now does), while unexpected bugs still surface as `org.freedesktop.DBus.Error.Failed` rather than as silence.

## Related, not blockers

- Waybar [#5145](https://github.com/Alexays/Waybar/issues/5145) (open) is the same freeze with a different MPRIS peer (`mpris-timer`); its "Method 3" reproduces identically to what Blanket causes.
- `playerctld` should return a D-Bus error rather than never replying when an upstream player's reply is malformed.
