### PR TITLE
fix: correctly catch missing dependencies

### DIFF
--- a/blanket/main.py
+++ b/blanket/main.py
@@ -18,7 +18,7 @@ try:
 
     # Init GStreamer
     Gst.init(None)
-except ImportError or ValueError as exc:
+except (ImportError, ValueError) as exc:
     print("Error: Dependencies not met.", exc)
     exit()
 


### PR DESCRIPTION
Updates *main.py* to properly catch `ValueError`.

The existing code does not catch the exception and the program terminates with

```
ValueError: Namespace Xdp not available
```

With the present commit, the error shown will be the intended

```
Error: Dependencies not met. Namespace Xdp not available
```